### PR TITLE
ELEC-36: Retarget STDOUT on STMF0xx

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ program: $(BIN_DIR)/$(PROJECT).bin
 gdb: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 	@$(OPENOCD) $(OPENOCD_CFG) > /dev/null 2>&1 &
 	@$(GDB) $< -ex "set pagination off" -ex "target extended-remote :3333" \
-						 -ex "monitor arm semihosting enable" -ex "monitor reset halt" \
+             -ex "monitor arm semihosting enable" -ex "monitor reset halt" \
              -ex "load" -ex "tb main" -ex "c"
 	@pkill openocd
 

--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,8 @@ program: $(BIN_DIR)/$(PROJECT).bin
 
 gdb: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 	@$(OPENOCD) $(OPENOCD_CFG) > /dev/null 2>&1 &
-	@$(GDB) $< -ex "set pagination off" -ex "target extended-remote :3333" -ex "monitor reset halt" \
+	@$(GDB) $< -ex "set pagination off" -ex "target extended-remote :3333" \
+						 -ex "monitor arm semihosting enable" -ex "monitor reset halt" \
              -ex "load" -ex "tb main" -ex "c"
 	@pkill openocd
 

--- a/libraries/stm32f0xx/inc/retarget.h
+++ b/libraries/stm32f0xx/inc/retarget.h
@@ -1,0 +1,4 @@
+#pragma once
+// Retargets standard IO to UART1
+
+void retarget_init(void);

--- a/libraries/stm32f0xx/src/retarget.c
+++ b/libraries/stm32f0xx/src/retarget.c
@@ -1,15 +1,19 @@
 #include "retarget.h"
 #include "stm32f0xx.h"
 
-#define min(x, y) (((x) <= (y)) ? (x) : (y))
+#define min(a,b) \
+  ({ __typeof__ (a) _a = (a); \
+     __typeof__ (b) _b = (b); \
+    _a <= _b ? _a : _b; })
 
-volatile char gv_data[500];
-volatile int gv_pos;
+#define RETARGET_BUFFER_SIZE 1000
 
-// TODO: putchar is not working
+char gv_buffer[RETARGET_BUFFER_SIZE] = { 0 };
+int gv_pos = 0;
+
 int _write(int fd, char *ptr, int len) {
-  int space = min(len, 500 - gv_pos - len);
-  memcpy(gv_data + gv_pos, ptr, space);
+  int space = min(len, RETARGET_BUFFER_SIZE - gv_pos - len);
+  memcpy(gv_buffer + gv_pos, ptr, space);
   gv_pos += space;
 
   return space;
@@ -21,7 +25,5 @@ void HardFault_Handler(void) {
 }
 
 void retarget_init(void) {
-  WWDG_DeInit();
-  gv_pos = 0;
   // Initialize UART
 }

--- a/libraries/stm32f0xx/src/retarget.c
+++ b/libraries/stm32f0xx/src/retarget.c
@@ -1,0 +1,27 @@
+#include "retarget.h"
+#include "stm32f0xx.h"
+
+#define min(x, y) (((x) <= (y)) ? (x) : (y))
+
+volatile char gv_data[500];
+volatile int gv_pos;
+
+// TODO: putchar is not working
+int _write(int fd, char *ptr, int len) {
+  int space = min(len, 500 - gv_pos - len);
+  memcpy(gv_data + gv_pos, ptr, space);
+  gv_pos += space;
+
+  return space;
+}
+
+void HardFault_Handler(void) {
+  __ASM volatile("BKPT #01");
+  while (1);
+}
+
+void retarget_init(void) {
+  WWDG_DeInit();
+  gv_pos = 0;
+  // Initialize UART
+}

--- a/libraries/stm32f0xx/src/retarget.c
+++ b/libraries/stm32f0xx/src/retarget.c
@@ -1,6 +1,10 @@
+// Retargets STDOUT to semihosting if SEMIHOSTING_ENABLED=1.
+// Note that semihosting will cause devices that aren't connected to a debugger to hang.
+// TODO(ELEC-36): Replace semihosting with UART
 #include "retarget.h"
 #include "stm32f0xx.h"
 
+// Send a command to OpenOCD - semihosting must be enabled
 static void send_command(int command, void *message) {
   __ASM volatile(
     "mov r0, %[cmd]\n"
@@ -19,7 +23,11 @@ int _write(int fd, char *ptr, int len) {
     len
   };
 
+#if SEMIHOSTING_ENABLED
+  // Only retarget to semihosting if explicitly enabled since
+  // our hard fault handler doesn't play nicely with semihosting
   send_command(0x05, m);
+#endif
 
   return len;
 }
@@ -30,5 +38,5 @@ void HardFault_Handler(void) {
 }
 
 void retarget_init(void) {
-  // Initialize UART
+  // Stub for UART initialization
 }

--- a/libraries/stm32f0xx/src/startup_stm32f0xx.s
+++ b/libraries/stm32f0xx/src/startup_stm32f0xx.s
@@ -116,6 +116,8 @@ LoopFillZerobss:
     bl  SystemInit
 /* Call static constructors */
     bl __libc_init_array
+/* Call the retarget function */
+    bl retarget_init
 /* Call the application's entry point.*/
   bl main
   

--- a/libraries/unity/inc/unity_internals.h
+++ b/libraries/unity/inc/unity_internals.h
@@ -262,6 +262,7 @@ typedef UNITY_FLOAT_TYPE _UF;
 #ifndef UNITY_OUTPUT_CHAR
 /* Default to using putchar, which is defined in stdio.h */
 #include <stdio.h>
+#undef putchar // Newlib defines putchar as a macro which does not work, so undefine it
 #define UNITY_OUTPUT_CHAR(a) (void)putchar(a)
 #else
   /* If defined as something else, make sure we declare it here so it's ready for use */

--- a/make/build.mk
+++ b/make/build.mk
@@ -39,7 +39,7 @@ $(STATIC_LIB_DIR)/lib$(T).a: $($(T)_OBJ) $(call dep_to_lib,$($(T)_DEPS)) | $(STA
 # Application target
 $(BIN_DIR)/$(T)$(PLATFORM_EXT): $($(T)_OBJ) $(call dep_to_lib,$($(T)_DEPS)) | $(BIN_DIR)
 	@echo "Building $(notdir $@) for $(PLATFORM)"
-	@$(CC) $(CFLAGS) -Wl,-Map=$(BIN_DIR)/$(notdir $@).map $^ -o $@ -L$(STATIC_LIB_DIR) \
+	@$(CC) $(CFLAGS) -Wl,-Map=$(BIN_DIR)/$(notdir $(@:%$(PLATFORM_EXT)=%.map)) $^ -o $@ -L$(STATIC_LIB_DIR) \
 		$(addprefix -l,$(APP_DEPS)) \
 		$(LDFLAGS) $(addprefix -I,$(INC_DIRS))
 	@$(OBJDUMP) -St $@ >$(basename $@).lst

--- a/make/build_test.mk
+++ b/make/build_test.mk
@@ -21,6 +21,8 @@ $(T)_TEST_RUNNERS := $($(T)_TEST_SRC:$($(T)_TEST_ROOT)/test_%.c=$($(T)_GEN_DIR)/
 $(T)_TEST_RUNNERS_OBJ := $($(T)_TEST_RUNNERS:$($(T)_GEN_DIR)/%.c=$($(T)_TEST_OBJ_DIR/%.o))
 -include $($(T)_TEST_RUNNERS_OBJ:.o=.d) #:
 
+.SECONDARY: $($(T)_TEST_RUNNERS)
+
 # Generate the expected build outputs - one for each runner
 $(T)_TESTS := $($(T)_TEST_RUNNERS:$($(T)_GEN_DIR)/%.c=$($(T)_TEST_BIN_DIR)/%$(PLATFORM_EXT))
 
@@ -44,7 +46,7 @@ $($(T)_TESTS): $($(T)_TEST_BIN_DIR)/%_runner$(PLATFORM_EXT): \
                  $($(T)_TEST_OBJ_DIR)/%.o $($(T)_TEST_OBJ_DIR)/%_runner.o \
                  $(call dep_to_lib,$($(T)_TEST_DEPS)) | $($(T)_TEST_BIN_DIR)
 	@echo "Building test $(notdir $@) for $(PLATFORM)"
-	@$(CC) $(CFLAGS) $^ -o $@ -L$(STATIC_LIB_DIR) \
+	@$(CC) $(CFLAGS) -Wl,-Map=$|/$(notdir $(@:%$(PLATFORM_EXT)=%.map)) $^ -o $@ -L$(STATIC_LIB_DIR) \
 		$(addprefix -l,$(APP_DEPS)) \
 		$(LDFLAGS) $(addprefix -I,$(INC_DIRS))
 

--- a/platform/stm32f0xx/platform.mk
+++ b/platform/stm32f0xx/platform.mk
@@ -20,7 +20,7 @@ LDSCRIPT := $(PLATFORM_DIR)/ldscripts
 
 # Build flags for the device
 CDEFINES := USE_STDPERIPH_DRIVER STM32F072
-CFLAGS := -Wall -Werror -g -Os -Wno-unused-variable -pedantic \
+CFLAGS := -Wall -Werror -g -Os -std=c99 -Wno-unused-variable -pedantic \
           -ffunction-sections -fdata-sections -fno-builtin -flto \
           --specs=nosys.specs --specs=nano.specs \
           $(ARCH_CLAGS) $(addprefix -D,$(CDEFINES))

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -21,7 +21,7 @@ LDSCRIPT := $(PLATFORM_DIR)/ldscripts
 
 # Build flags for the device
 CDEFINES :=
-CFLAGS := -Wall -Werror -g -Os -Wno-unused-variable -pedantic \
+CFLAGS := -Wall -Werror -g -Os -std=c99 -Wno-unused-variable -pedantic \
           -ffunction-sections -fdata-sections \
           -Wl,-Map=$(BIN_DIR)/$(PROJECT).map \
           $(ARCH_CLAGS) $(addprefix -D,$(CDEFINES))


### PR DESCRIPTION
Currently redirects stdout to semihosting - once we receive UART to USB adapters, I'll switch it to UART.

I found that if you include stdio.h, putchar is defined as both a function and a macro, and that macro overrides the function declaration with an inlined function that doesn't work. For unity, I undefined the macro. For everything else, just don't use putchar. :)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/uw-midsun/firmware/11)
<!-- Reviewable:end -->
