### PR TITLE
ELEC-60: Configure Travis to build PRs and master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,13 @@ notifications:
 
 language: c
 
+# enable "Build pushes" and "Build pull requests" in Travis CI
+# - pull requests will always be built
+# - only build pushes to master
+branches:
+  only:
+    - master
+
 env:
   # add target platforms to build matrix
   # lint is a target so we don't need to lint multiple times


### PR DESCRIPTION
Currently Travis CI is configured to build on every **push**, and every **pull** request (running tests as if the PR is merged). This isn't great, since disabling Travis for push requests via the settings means that tests against the master branch are not run whenever PRs are merged.

This change configures Travis so that it builds against every merge into **master** (a **push** request, since we never push directly to master) and on every PR (a **pull** request).