### PR TITLE
ELEC-79: Added test specifier for unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ env:
   # lint is a target so we don't need to lint multiple times
   - TARGET='build_all PLATFORM=x86'
   - TARGET='build_all PLATFORM=stm32f0xx'
+  - TARGET='test_all PLATFORM=x86'
   - TARGET=lint
 
 before_install:

--- a/Makefile
+++ b/Makefile
@@ -144,7 +144,7 @@ lint:
 # Builds the project
 project: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 
-build_all: $(VALID_PROJECTS:%=$(BIN_DIR)/%$(PLATFORM_EXT)) test_all
+build_all: $(VALID_PROJECTS:%=$(BIN_DIR)/%$(PLATFORM_EXT))
 
 $(DIRS):
 	@mkdir -p $@

--- a/make/build_test.mk
+++ b/make/build_test.mk
@@ -51,19 +51,22 @@ $($(T)_TESTS): $($(T)_TEST_BIN_DIR)/%_runner$(PLATFORM_EXT): \
 		$(LDFLAGS) $(addprefix -I,$(INC_DIRS))
 
 .PHONY: test test_ test_$(T)
-# Only include the library tests as a target if we aren't testing a project
-ifeq (,$(PROJECT))
-test: test_$(LIBRARY)
-test_: # Fake target for unspecified tests
+
+ifeq ($(T),$(filter $(T),$(LIBRARY) $(PROJECT)))
+ifeq (,$(TEST))
+test: test_$(T)
+else
+test: $($(T)_TEST_BIN_DIR)/test_$(TEST)_runner$(PLATFORM_EXT)
+	@echo "Running test - $(TEST)"
+	@$(call run_test,$<)
+
+endif
 endif
 
 # Run each test
 test_$(T): $($(T)_TESTS)
-# Only run unit tests on x86
-ifneq (,$(filter x86,$(PLATFORM)))
 	@echo "Running test suite - $(@:test_%=%)"
-	@$(foreach test,$^,echo "\nRunning $(notdir $(test))" && ./$(test) &&) true
-endif
+	@$(foreach test,$^,$(call run_test,$<) &&) true
 
 test_all: test_$(T)
 

--- a/make/build_test.mk
+++ b/make/build_test.mk
@@ -70,5 +70,7 @@ test_$(T): $($(T)_TESTS)
 
 test_all: test_$(T)
 
+build_all: $($(T)_TESTS)
+
 DIRS := $(sort $(DIRS) $($(T)_GEN_DIR) $($(T)_TEST_BIN_DIR) \
                $(dir $($(T)_TEST_OBJ) $($(T)_TEST_RUNNERS_OBJ)))

--- a/platform/stm32f0xx/platform.mk
+++ b/platform/stm32f0xx/platform.mk
@@ -57,3 +57,15 @@ semihosting: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
     tmux kill-session -t \"ms-fw\"" C-m
 	@tmux select-pane -t 0
 	@tmux attach -t "ms-fw"
+
+# Defines a command to run for unit testing
+define run_test
+tmux new-session -s "ms-fw" -d;
+tmux split-window -h -t "ms-fw":0;
+tmux send-keys -t "ms-fw":0.1 "$(OPENOCD) $(OPENOCD_CFG)" C-m;
+tmux send-keys -t "ms-fw":0.0 \
+  "$(GDB) $< -x \"$(SCRIPT_DIR)/gdb_flash\"; \
+  tmux kill-session -t \"ms-fw\"" C-m;
+tmux select-pane -t 0;
+tmux attach -t "ms-fw"
+endef

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -30,7 +30,15 @@ CFLAGS := -Wall -Werror -g -Os -std=gnu99 -Wno-unused-variable -pedantic \
 LDFLAGS :=
 
 # Platform targets
-.PHONY: run
+.PHONY: run gdb
 
 run: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 	@$<
+
+gdb: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
+	@$(GDB) $<
+
+# Defines a command to run for unit testing
+define run_test
+echo "\nRunning $(notdir $1)" && ./$(1)
+endef


### PR DESCRIPTION
Added ability to specify a unit test to run with `TEST=`. Requires `LIBRARY` or `PROJECT` to be defined.
Also fixed `make test` running all tests.