### PR TITLE
ELEC-36 Fixed a bug/typo that caused Semihosting to not enable.

### DIFF
--- a/platform/stm32f0xx/platform.mk
+++ b/platform/stm32f0xx/platform.mk
@@ -22,7 +22,7 @@ LDSCRIPT_DIR := $(PLATFORM_DIR)/ldscripts
 SCRIPT_DIR := $(PLATFORM_DIR)/scripts
 
 # Build flags for the device
-CDEFINES := USE_STDPERIPH_DRIVER STM32F072 SEMIHOSTING
+CDEFINES := USE_STDPERIPH_DRIVER STM32F072 SEMIHOSTING_ENABLED
 CFLAGS := -Wall -Werror -g -Os -std=c99 -Wno-unused-variable -pedantic \
           -ffunction-sections -fdata-sections -fno-builtin -flto \
           --specs=nosys.specs --specs=nano.specs \


### PR DESCRIPTION
Fixed a typo where SEMIHOSTING in platform.mk for stm32f0xx should have read SEMIHOSTING_ENABLED. This now allows semihosting to work.