### PR TITLE
ELEC-95 Specify void as arg for some functions.

### DIFF
--- a/libraries/ms-common/inc/gpio.h
+++ b/libraries/ms-common/inc/gpio.h
@@ -59,7 +59,7 @@ typedef struct GPIOSettings {
 
 // Initializes GPIO globally by setting all pins to their default state. ONLY CALL ONCE or it will
 // deinit all current settings. Change setting by calling gpio_init_pin.
-StatusCode gpio_init();
+StatusCode gpio_init(void);
 
 // Initializes a GPIO pin by address.
 StatusCode gpio_init_pin(GPIOAddress *address, GPIOSettings *settings);

--- a/libraries/ms-common/inc/status.h
+++ b/libraries/ms-common/inc/status.h
@@ -69,7 +69,7 @@ StatusCode status_impl_update(const StatusCode code, const char* source, const c
                               const char* message);
 
 // Get a copy of the global status so it can be used safely.
-Status status_get();
+Status status_get(void);
 
 // Set a callback that is run whenever the status is changed.
 void status_register_callback(status_callback callback);

--- a/libraries/ms-common/src/status.c
+++ b/libraries/ms-common/src/status.c
@@ -17,7 +17,7 @@ StatusCode status_impl_update(const StatusCode code, const char* source, const c
   return code;
 }
 
-Status status_get() {
+Status status_get(void) {
   return s_global_status;
 }
 

--- a/libraries/ms-common/src/stm32f0xx/gpio.c
+++ b/libraries/ms-common/src/stm32f0xx/gpio.c
@@ -35,7 +35,7 @@ static bool prv_are_settings_valid(const GPIOSettings *settings) {
            settings->resistor >= NUM_GPIO_RES || settings->alt_function >= NUM_GPIO_ALTFN);
 }
 
-StatusCode gpio_init() {
+StatusCode gpio_init(void) {
   for (uint32_t i = 0; i < GPIO_NUM_PORTS; i++) {
     // Sets the pin to a default reset mode.
     // TODO(ELEC-20): determine if this is actually Lowest Power setting.

--- a/libraries/ms-common/src/x86/gpio.c
+++ b/libraries/ms-common/src/x86/gpio.c
@@ -32,7 +32,7 @@ static uint32_t prv_get_index(GPIOAddress *address) {
   return address->port * MAX_PORTS + address->pin;
 }
 
-StatusCode gpio_init() {
+StatusCode gpio_init(void) {
   // TODO(ELEC-39): Check if MAX_PORTS and MAX_PINS get defined if not fail as the configuration
   // is bad.
   GPIOSettings default_settings = { .direction = GPIO_DIR_IN,


### PR DESCRIPTION
Trivial change that specifies void arguments for a few functions I wrote in C++ style not knowing any better.