### PR TITLE
ELEC-111 Clang Tools Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,6 @@ tags
 .ycm_extra_conf.py
 *.swp
 __pycache__
+
+# Compile database
+compile_commands.json

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@
 #		PR: [PROJECT=] - Specifies the target project
 #		LI: [LIBRARY=] - Specifies the target library (only valid for tests)
 #		TE: [TEST=] - Specifies the target test (only valid for tests, requires LI or PR to be specified)
+#		CM: [COMPILER=] - Specifies the compiler to use on x86. Defualts to gcc [gcc | clang].
+#		CO: [COPTIONS=] - Specifies compiler options on x86 [asan | tsan].
 #
 # Usage:
 #		make [all] [PL] [PR] - Builds the target project and its dependencies
@@ -18,6 +20,7 @@
 # Platform specific:
 #		make program [PL=stm32f0xx] [PR] - Programs and runs the project through OpenOCD
 #		make semihosting [PL=stm32f0xx] [PR] - Opens an instance of tmux to view both GDB and OpenOCD and runs the project
+#		make <build | test | remake | all> [PL=x86] [CM=clang [CO]]
 #
 ###################################################################################################
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/uw-midsun/firmware.svg?branch=master)](https://travis-ci.org/uw-midsun/firmware)
 
-This repository contains all the latest firmware for the [University of Waterloo](https://uwaterloo.ca/)'s [Midnight Sun Solar Rayce Car](http://www.uwmidsun.com/) team. 
+This repository contains all the latest firmware for the [University of Waterloo](https://uwaterloo.ca/)'s [Midnight Sun Solar Rayce Car](http://www.uwmidsun.com/) team.
 
 
 ## Building and Testing
@@ -35,6 +35,47 @@ To test against code standards, run ``make lint``.
 
 More information on building and testing can be found in our [Makefile](Makefile) and our [platform build rules](platform).
 
+### Optional x86 Extended Debugging
+
+If you have Clang/LLVM/Bear installed and want to debug on x86 more easily/more in depth.
+
+#### Static Analysis
+
+To create a compile commands database, run
+
+```bash
+make reallyclean
+bear make build_all PLATFORM=x86
+```
+
+Then to perform static analysis, run
+
+```bash
+clang-tidy $PATH_TO_C_FILE -checks=*
+```
+
+#### Address Sanitation, Memory Analysis and Stack Pointers
+
+To build in debug with memory and address sanitation and extended stack traces on faults, run
+
+```bash
+make reallyclean
+make build_all PLATFORM=x86 COMPILER=clang COPTIONS=asan
+```
+
+If you run any of the resulting binaries and a memory error of any kind occurs there will be detailed information on the cause.
+
+#### Thread Sanitation
+
+To build in debug with thread sanitation run
+
+```bash
+make reallyclean
+make build_all PLATFORM=x86 COMPILER=clang COPTIONS=tsan
+```
+
+If you run any of the resulting binaries and there is any multithreaded code this will find any race conditions.
+
 ## Continuous Integration
 
 We use [Travis CI](https://travis-ci.org/uw-midsun) to run our continuous integration tests, which consists of linting project code, and compiling and running unit tests against each supported platform. The build matrix is used to run tests on all possible permutations of our build targets (including linting, which is listed as a target to prevent linting the same code multiple times).
@@ -49,6 +90,11 @@ More information can be found by reading our [.travis.yml](.travis.yml) file.
 * GNU Make 4.0 or above
 * [Unity&mdash;Throw the Switch](http://www.throwtheswitch.org/unity/): our C unit testing framework
 * [ms-common](https://github.com/uw-midsun/ms-common): our Hardware Abstraction Layer, and other shared libraries
+
+### Optional Dependencies:
+
+* [Clang/LLVM toolchain](http://releases.llvm.org/download.html)
+* [Bear (Build EAR)](https://github.com/rizsotto/Bear)
 
 ## Contributions
 Before submitting an issue or a pull request to the project, please take a moment to review our code style guide first.


### PR DESCRIPTION
Added support and documentation for optionally using clang instead of gcc on x86. This adds support for memory sanitization, leak checking and stack traces via ASAN and race condition checks via TSAN. Also added documentation on using Build EAR and clang-tidy for static analysis.

For users uninterested in these features they are entirely opt-in, there is no change to the existing build workflow and no additional downloads are needed to keep working as you have been. They simply make my life easier when writing x86 code. 

Added variables to the x86 paltform.mk for `COMPILER= [gcc | clang] COPTIONS = [asan | tsan]`. gcc without options remains the default.

@karlding I'll leave it up to you whether or not to change/add a Travis CI check for x86 tests that builds with ASAN enabled. This would provide stack traces on segfaults which would be nice but it would also entail adding clang/llvm to the CI. The bash for this would be

```bash
$ make test PLATFORM=x86 COMPILER=clang COPTIONS=asan
```