### PR TITLE
ELEC-116 x86_interrupt bug fix.

### DIFF
--- a/libraries/ms-common/inc/gpio.h
+++ b/libraries/ms-common/inc/gpio.h
@@ -4,7 +4,7 @@
 
 #include "status.h"
 
-// GPIO address to be used to change that pin's settings
+// GPIO address to be used to change that pin's settings. Both port and pin are zero indexed.
 typedef struct GPIOAddress {
   uint8_t port;
   uint8_t pin;


### PR DESCRIPTION
Calling getpid() from a thread other than the main thread would result in an incorrect software interrupt trigger. To resolve this issue a static pid should be recorded from the initializing thread.

Update gpio.h docs.