### PR TITLE
ELEC-143: CMSIS-DAP support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -80,6 +80,13 @@ STATIC_LIB_DIR := $(BUILD_DIR)/lib/$(PLATFORM)
 # Object cache
 OBJ_CACHE := $(BUILD_DIR)/obj/$(PLATFORM)
 
+# Set GDB target
+ifeq (,$(TEST))
+GDB_TARGET := $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
+else
+GDB_TARGET = $(BIN_DIR)/test/$(LIBRARY)$(PROJECT)/test_$(TEST)_runner$(PLATFORM_EXT)
+endif
+
 DIRS := $(BUILD_DIR) $(BIN_DIR) $(STATIC_LIB_DIR) $(OBJ_CACHE)
 
 # Please don't touch anything below this line

--- a/Makefile
+++ b/Makefile
@@ -18,9 +18,9 @@
 #		make lint - Lints all non-vendor code
 #		make test [PL] [PR|LI] [TE] - Builds and runs the specified unit test, assuming all tests if TE is not defined
 #		make gdb [PL] [PR] - Builds and runs the project and connects an instance of GDB for debugging
+#   make gdb [PL] [PR|LI] [TE] - Builds and runs the specified unit test and connects an instance of GDB
 # Platform specific:
 #		make program [PL=stm32f0xx] [PR] [PB] - Programs and runs the project through OpenOCD
-#		make debug [PL=stm32f0xx] [PR] [PB] - Opens an instance of tmux to view both GDB and serial output
 #	  make gdb [PL=stm32f0xx] [PL] [PR] [PB]
 #		make <build | test | remake | all> [PL=x86] [CM=clang [CO]]
 #
@@ -49,7 +49,7 @@ override LIBRARY := $(filter $(VALID_LIBRARIES),$(LIBRARY))
 # Only ignore project and platform if we're doing a full clean or lint
 ifeq (,$(filter reallyclean lint build_all test_all,$(MAKECMDGOALS)))
 # If not running a test, only care about project
-ifeq (,$(filter test,$(MAKECMDGOALS)))
+ifeq (,$(filter test gdb,$(MAKECMDGOALS)))
 ifeq (,$(PROJECT))
   $(error Invalid project. Expected PROJECT=[$(VALID_PROJECTS)])
 endif

--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@
 #		TE: [TEST=] - Specifies the target test (only valid for tests, requires LI or PR to be specified)
 #		CM: [COMPILER=] - Specifies the compiler to use on x86. Defualts to gcc [gcc | clang].
 #		CO: [COPTIONS=] - Specifies compiler options on x86 [asan | tsan].
+#   PB: [PROBE=] - Specifies which debug probe to use on STM32F0xx. Defaults to cmsis-dap [cmsis-dap | stlink-v2].
 #
 # Usage:
 #		make [all] [PL] [PR] - Builds the target project and its dependencies
@@ -18,8 +19,9 @@
 #		make test [PL] [PR|LI] [TE] - Builds and runs the specified unit test, assuming all tests if TE is not defined
 #		make gdb [PL] [PR] - Builds and runs the project and connects an instance of GDB for debugging
 # Platform specific:
-#		make program [PL=stm32f0xx] [PR] - Programs and runs the project through OpenOCD
-#		make semihosting [PL=stm32f0xx] [PR] - Opens an instance of tmux to view both GDB and OpenOCD and runs the project
+#		make program [PL=stm32f0xx] [PR] [PB] - Programs and runs the project through OpenOCD
+#		make debug [PL=stm32f0xx] [PR] [PB] - Opens an instance of tmux to view both GDB and serial output
+#	  make gdb [PL=stm32f0xx] [PL] [PR] [PB]
 #		make <build | test | remake | all> [PL=x86] [CM=clang [CO]]
 #
 ###################################################################################################

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#firmware
+# firmware
 
 [![Build Status](https://travis-ci.org/uw-midsun/firmware.svg?branch=master)](https://travis-ci.org/uw-midsun/firmware)
 
@@ -10,16 +10,14 @@ This repository contains all the latest firmware for the [University of Waterloo
 ```bash
 git clone https://github.com/uw-midsun/firmware.git firmware
 cd firmware
-git submodule update --init --recursive
+make build_all PLATFORM=x86
+make build_all PLATFORM=stm32f0xx
+make test_all PLATFORM=x86
 ```
 
 We use the GNU ARM Embedded toolchain to build all our firmware.
 
-```bash
-make build_all PLATFORM=x86
-```
-
-To build a project, run ``make project PROJECT=$PROJECT PLATFORM=$PLATFORM``, where ``$PROJECT`` is a valid project name, and ``$PLATFORM`` is a supported platform.
+To build a project, run ``make PROJECT=$PROJECT PLATFORM=$PLATFORM``, where ``$PROJECT`` is a valid project name, and ``$PLATFORM`` is a supported platform.
 
 **Note**: If not specified, ``$PLATFORM`` is set to ``stm32f0xx`` by default.
 

--- a/make/build_test.mk
+++ b/make/build_test.mk
@@ -58,7 +58,7 @@ test: test_$(T)
 else
 test: $($(T)_TEST_BIN_DIR)/test_$(TEST)_runner$(PLATFORM_EXT)
 	@echo "Running test - $(TEST)"
-	@$(call run_test,$<)
+	@$(call session_wrapper,$(call test_run,$<))
 
 endif
 endif
@@ -66,7 +66,7 @@ endif
 # Run each test
 test_$(T): $($(T)_TESTS)
 	@echo "Running test suite - $(@:test_%=%)"
-	@$(foreach test,$^,$(call run_test,$(test)) &&) true
+	@$(call session_wrapper,$(foreach test,$^,$(call test_run,$(test)) &&) true)
 
 test_all: test_$(T)
 

--- a/platform/stm32f0xx/platform.mk
+++ b/platform/stm32f0xx/platform.mk
@@ -45,12 +45,6 @@ OPENOCD_CFG := -s $(OPENOCD_SCRIPT_DIR) \
 program: $(BIN_DIR)/$(PROJECT).bin
 	@$(OPENOCD) $(OPENOCD_CFG) -c "stm_flash `pwd`/$<" -c shutdown
 
-ifeq (,$(TEST))
-GDB_TARGET := $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
-else
-GDB_TARGET = $(BIN_DIR)/test/$(LIBRARY)$(PROJECT)/test_$(TEST)_runner$(PLATFORM_EXT)
-endif
-
 gdb: $(GDB_TARGET)
 	@$(OPENOCD) $(OPENOCD_CFG) > /dev/null 2>&1 &
 	@$(GDB) $< -x "$(SCRIPT_DIR)/gdb_flash"

--- a/platform/stm32f0xx/platform.mk
+++ b/platform/stm32f0xx/platform.mk
@@ -40,7 +40,7 @@ OPENOCD_CFG := -s $(OPENOCD_SCRIPT_DIR) \
                -f $(SCRIPT_DIR)/stm32f0-openocd.cfg
 
 # Platform targets
-.PHONY: program gdb semihosting
+.PHONY: program gdb debug
 
 program: $(BIN_DIR)/$(PROJECT).bin
 	@$(OPENOCD) $(OPENOCD_CFG) -c "stm_flash `pwd`/$<" -c shutdown
@@ -51,29 +51,19 @@ gdb: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 	@pkill openocd
 
 debug: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
-	@tmux new-session -s "ms-fw" -d
-	@tmux split-window -h -t "ms-fw":0
-	@tmux send-keys -t "ms-fw":0.1 "echo this should be the serial output" C-m
-	@tmux send-keys -t "ms-fw":0.0 "$(OPENOCD) $(OPENOCD_CFG) > /dev/null 2>&1 &" C-m
-	@tmux send-keys -t "ms-fw":0.0 \
-    "clear; \
-    $(GDB) $< -x \"$(SCRIPT_DIR)/gdb_flash\"; \
-    pkill openocd; \
-    tmux kill-session -t \"ms-fw\"" C-m
-	@tmux select-pane -t 0
-	@tmux attach -t "ms-fw"
+	@$(call session_wrapper,$(GDB) $< -x "$(SCRIPT_DIR)/gdb_flash")
 
-# Defines a command to run for unit testing
-define run_test
+define session_wrapper
 tmux new-session -s "ms-fw" -d;
 tmux split-window -h -t "ms-fw":0;
 tmux send-keys -t "ms-fw":0.1 "echo this should be the serial output" C-m
 tmux send-keys -t "ms-fw":0.0 "$(OPENOCD) $(OPENOCD_CFG) > /dev/null 2>&1 &" C-m;
-tmux send-keys -t "ms-fw":0.0 \
-  "clear; \
-  $(GDB) $1 -x \"$(SCRIPT_DIR)/gdb_flash\"; \
-  pkill openocd; \
-  tmux kill-session -t \"ms-fw\"" C-m;
+tmux send-keys -t "ms-fw":0.0 '$1; pkill openocd; tmux kill-session -t "ms-fw"' C-m;
 tmux select-pane -t 0;
 tmux attach -t "ms-fw"
+endef
+
+# Defines command to run for unit testing
+define test_run
+clear && $(GDB) $1 -x "$(SCRIPT_DIR)/gdb_flash" -ex "b LoopForever" -ex "c" -ex "set confirm off" -ex "q"
 endef

--- a/platform/stm32f0xx/scripts/gdb_flash
+++ b/platform/stm32f0xx/scripts/gdb_flash
@@ -10,4 +10,5 @@ target extended-remote :3333
 monitor reset halt
 load
 tb main
+tb LoopForever
 c

--- a/platform/stm32f0xx/scripts/gdb_flash
+++ b/platform/stm32f0xx/scripts/gdb_flash
@@ -6,7 +6,7 @@ set history save on
 set history size unlimited
 set history filename ~/.gdb_history
 target extended-remote :3333
-monitor arm semihosting enable
+# monitor arm semihosting enable
 monitor reset halt
 load
 tb main

--- a/platform/stm32f0xx/scripts/stm32f0-openocd.cfg
+++ b/platform/stm32f0xx/scripts/stm32f0-openocd.cfg
@@ -9,7 +9,7 @@ proc stm_flash {IMGFILE} {
 	sleep 100
 	wait_halt 2
 	flash write_image erase $IMGFILE 0x08000000
-	sleep 100 
+	sleep 100
 	verify_image $IMGFILE 0x08000000
 	sleep 100
 	reset run

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -56,7 +56,11 @@ run: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 gdb: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 	@$(GDB) $<
 
-# Defines a command to run for unit testing
-define run_test
+define session_wrapper
+$1
+endef
+
+# Defines command to run for unit testing
+define test_run
 echo "\nRunning $(notdir $1)" && ./$(1)
 endef

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -53,7 +53,7 @@ LDFLAGS := -lrt
 run: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 	@$<
 
-gdb: $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
+gdb: $(GDB_TARGET)
 	@$(GDB) $<
 
 define session_wrapper

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -62,5 +62,5 @@ endef
 
 # Defines command to run for unit testing
 define test_run
-echo "\nRunning $(notdir $1)" && ./$(1)
+echo "\nRunning $(notdir $1)" && ./$1
 endef


### PR DESCRIPTION
Adds support for our ST-Link clones running the dap42 firmware and cleans up test handling a lot. Uses the CMSIS-DAP probe by default - to use with an stlink, add `PROBE=stlink-v2`.

Serial support is still a TODO - I wasn't able to pass the serial port through to my VM properly. @ckitagawa, can you let me know what setup you ended up using to receive serial data?