### PR TITLE
ELEC-153: Remove qq flag from GCC ARM install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script:
   # install GCC ARM from GNU ARM Embedded Toolchain PPA
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get -qq update
-  - sudo apt-get -qq install gcc-arm-embedded
+  - sudo apt-get -y install gcc-arm-embedded
 
   # build GNU Make 4.1 from source
   - wget http://ftp.gnu.org/gnu/make/make-4.1.tar.gz


### PR DESCRIPTION
Replace ``-qq`` flag with ``-y``.

```
-qq No output except for errors
```

Travis is killing the job due to installs taking more than 10 minutes. Since `qq` suppresses all output, no output is produced, and Travis will kill any job with [no log output produced](https://docs.travis-ci.com/user/customizing-the-build#Build-Timeouts).