### PR TITLE
ELEC-160: Fixed GDB target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ OBJ_CACHE := $(BUILD_DIR)/obj/$(PLATFORM)
 
 # Set GDB target
 ifeq (,$(TEST))
-GDB_TARGET := $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
+GDB_TARGET = $(BIN_DIR)/$(PROJECT)$(PLATFORM_EXT)
 else
 GDB_TARGET = $(BIN_DIR)/test/$(LIBRARY)$(PROJECT)/test_$(TEST)_runner$(PLATFORM_EXT)
 endif

--- a/platform/stm32f0xx/platform.mk
+++ b/platform/stm32f0xx/platform.mk
@@ -29,7 +29,7 @@ CFLAGS := -Wall -Werror -g -Os -std=c99 -Wno-unused-variable -pedantic \
           $(ARCH_CLAGS) $(addprefix -D,$(CDEFINES))
 
 # Linker flags
-LDFLAGS := $(CLFLAGS) -L$(LDSCRIPT_DIR) -Tstm32f0.ld -fuse-linker-plugin
+LDFLAGS := -L$(LDSCRIPT_DIR) -Tstm32f0.ld -fuse-linker-plugin
 
 # Device openocd config file
 # Use PROBE=stlink-v2 for discovery boards


### PR DESCRIPTION
`GDB_TARGET` was being evaluated before `PLATFORM_EXT` was assigned. Switched to lazy evaluation to fix it.