### PR TITLE
ELEC-159: Support excluding tests per-platform

### DIFF
--- a/libraries/CMSIS/rules.mk
+++ b/libraries/CMSIS/rules.mk
@@ -1,14 +1,14 @@
-# Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the library makefile.
+# Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src/*.c
-# $(T)_INC: $(T)_DIR/inc/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # Redefine the source and include root folders
 $(T)_SRC_ROOT := $($(T)_DIR)/Device/ST/STM32F0xx/Source/Templates
 $(T)_INC_DIRS := $($(T)_DIR)/Device/ST/STM32F0xx/Include \
-                   $($(T)_DIR)/Include
+                 $($(T)_DIR)/Include
 
 $(T)_DEPS :=
 

--- a/libraries/CMSIS/rules.mk
+++ b/libraries/CMSIS/rules.mk
@@ -10,9 +10,6 @@ $(T)_SRC_ROOT := $($(T)_DIR)/Device/ST/STM32F0xx/Source/Templates
 $(T)_INC_DIRS := $($(T)_DIR)/Device/ST/STM32F0xx/Include \
                    $($(T)_DIR)/Include
 
-# Redefine $(T)_SRC to reflect the new root
-$(T)_SRC := $(wildcard $($(T)_SRC_ROOT)/*.c)
-$(T)_INC := $(call find_in,$($(T)_INC_DIRS),*.h)
 $(T)_DEPS :=
 
 # Specifies library specific build flags

--- a/libraries/STM32F0xx_StdPeriph_Driver/rules.mk
+++ b/libraries/STM32F0xx_StdPeriph_Driver/rules.mk
@@ -1,4 +1,5 @@
 # Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
 # $(T)_INC_DIRS: $(T)_DIR/inc

--- a/libraries/STM32F0xx_StdPeriph_Driver/rules.mk
+++ b/libraries/STM32F0xx_StdPeriph_Driver/rules.mk
@@ -2,9 +2,8 @@
 # Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM}}/*.{c,s}
-# $(T)_INC: $(T)_DIR/inc{/$(PLATFORM}}/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 $(T)_DEPS := CMSIS
 

--- a/libraries/ms-common/rules.mk
+++ b/libraries/ms-common/rules.mk
@@ -1,4 +1,5 @@
 # Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
 # $(T)_INC_DIRS: $(T)_DIR/inc

--- a/libraries/ms-common/rules.mk
+++ b/libraries/ms-common/rules.mk
@@ -2,8 +2,7 @@
 # Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM}}/*.{c,s}
-# $(T)_INC: $(T)_DIR/inc{/$(PLATFORM}}/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 $(T)_DEPS := $(PLATFORM_LIB)

--- a/libraries/stm32f0xx/rules.mk
+++ b/libraries/stm32f0xx/rules.mk
@@ -1,4 +1,5 @@
 # Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
 # $(T)_INC_DIRS: $(T)_DIR/inc

--- a/libraries/stm32f0xx/rules.mk
+++ b/libraries/stm32f0xx/rules.mk
@@ -2,9 +2,8 @@
 # Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM}}/*.{c,s}
-# $(T)_INC: $(T)_DIR/inc{/$(PLATFORM}}/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # This library glues the standard peripheral and CMSIS libraries together
 # and includes the startup file.

--- a/libraries/unity/rules.mk
+++ b/libraries/unity/rules.mk
@@ -1,4 +1,5 @@
 # Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
 # $(T)_INC_DIRS: $(T)_DIR/inc

--- a/libraries/unity/rules.mk
+++ b/libraries/unity/rules.mk
@@ -2,6 +2,5 @@
 # Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM}}/*.{c,s}
-# $(T)_INC: $(T)_DIR/inc{/$(PLATFORM}}/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}

--- a/libraries/x86/rules.mk
+++ b/libraries/x86/rules.mk
@@ -1,4 +1,5 @@
 # Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
 # $(T)_INC_DIRS: $(T)_DIR/inc

--- a/libraries/x86/rules.mk
+++ b/libraries/x86/rules.mk
@@ -2,12 +2,9 @@
 # Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM}}/*.{c,s}
-# $(T)_INC: $(T)_DIR/inc{/$(PLATFORM}}/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
-# This library glues the standard peripheral and CMSIS libraries together
-# and includes the startup file.
 $(T)_DEPS :=
 
 # Specifies library specific build flags

--- a/make/build.mk
+++ b/make/build.mk
@@ -13,18 +13,24 @@ $(T)_DIR := $($(TARGET_TYPE)_DIR)/$(T)
 
 $(T)_SRC_ROOT := $($(T)_DIR)/src
 $(T)_OBJ_ROOT := $(OBJ_CACHE)/$(T)
-$(T)_INC_DIRS := $($(T)_DIR)/inc
-
-$(T)_SRC := $(wildcard $($(T)_SRC_ROOT)/*.c) \
-            $(wildcard $($(T)_SRC_ROOT)/$(PLATFORM)/*.c) \
-            $(wildcard $($(T)_SRC_ROOT)/*.s)
-$(T)_INC := $(wildcard $($(T)_INC_DIRS)/*.h) \
-            $(wildcard $($(T)_INC_DIRS)/$(PLATFORM)/*.h)
+$(T)_INC_DIRS := $($(T)_DIR)/inc $($(T)_DIR)/inc/$(PLATFORM)
 
 $(T)_CFLAGS := $(CFLAGS)
 
 # Include library variables - we expect to have $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS
 include $($(T)_DIR)/rules.mk
+
+# If the source or include files were not explicitly defined, use the possibly modified
+# source root and include directories to find the source and headers.
+ifeq (,$($(T)_SRC))
+$(T)_SRC := $(wildcard $($(T)_SRC_ROOT)/*.c) \
+            $(wildcard $($(T)_SRC_ROOT)/$(PLATFORM)/*.c) \
+            $(wildcard $($(T)_SRC_ROOT)/*.s)
+endif
+ifeq (,$($(T)_INC))
+$(T)_INC := $(call find_in,$($(T)_INC_DIRS),*.h) \
+            $(call find_in,$($(T)_INC_DIRS),$(PLATFORM)/*.h)
+endif
 
 # Define objects and include generated dependencies
 # Note that without some very complex rules, we can only support one root source directory.

--- a/make/build.mk
+++ b/make/build.mk
@@ -27,10 +27,6 @@ $(T)_SRC := $(wildcard $($(T)_SRC_ROOT)/*.c) \
             $(wildcard $($(T)_SRC_ROOT)/$(PLATFORM)/*.c) \
             $(wildcard $($(T)_SRC_ROOT)/*.s)
 endif
-ifeq (,$($(T)_INC))
-$(T)_INC := $(call find_in,$($(T)_INC_DIRS),*.h) \
-            $(call find_in,$($(T)_INC_DIRS),$(PLATFORM)/*.h)
-endif
 
 # Define objects and include generated dependencies
 # Note that without some very complex rules, we can only support one root source directory.
@@ -73,4 +69,4 @@ ifneq (unity,$(T))
 endif
 
 DIRS := $(sort $(DIRS) $($(T)_OBJ_DIR) $(dir $($(T)_OBJ)))
-INC_DIRS := $(sort $(INC_DIRS) $(dir $($(T)_INC)))
+INC_DIRS := $(sort $(INC_DIRS) $($(T)_INC_DIRS))

--- a/make/build_test.mk
+++ b/make/build_test.mk
@@ -13,6 +13,11 @@ $(T)_TEST_DEPS := unity $(T)
 
 # Find all test_*.c files - these are our unit tests
 $(T)_TEST_SRC := $(wildcard $($(T)_TEST_ROOT)/test_*.c)
+
+# Exclude any tests explicitly mentioned - this allows tests to be disabled per platform.
+$(T)_EXCLUDED_TESTS := $(foreach test,$($(T)_EXCLUDE_TESTS),$($(T)_TEST_ROOT)/test_$(test).c)
+$(T)_TEST_SRC := $(filter-out $($(T)_EXCLUDED_TESTS),$($(T)_TEST_SRC))
+
 $(T)_TEST_OBJ := $($(T)_TEST_SRC:$($(T)_TEST_ROOT)/%.c=$($(T)_TEST_OBJ_DIR)/%.o)
 -include $($(T)_TEST_OBJ:.o=.d) #:
 

--- a/project/README.md
+++ b/project/README.md
@@ -1,6 +1,6 @@
 # Projects
 
-Projects are stored in this directory. Each folder represents an individual project, identified by the folder's name and the existance of a `rules.mk` in the folder's root.
+Projects are stored in this directory. Each folder represents an individual project, identified by the folder's name and the existence of a `rules.mk` in the folder's root.
 
 This is an example of a standard project's structure.
 ````
@@ -35,7 +35,7 @@ Unit tests should be located in the `test` subdirectory. Tests are built using [
 
 | Variable | Purpose | Default Value | Notes |
 |----------|---------|---------------|-------|
-| `$(T)_DEPS` | Define the libraries that this target depends on. | | A common depedency for projects is `ms-common`, which is our HAL. |
+| `$(T)_DEPS` | Define the libraries that this target depends on. | | A common dependency for projects is `ms-common`, which is our HAL. |
 | `$(T)_SRC_ROOT` | Modify the source file (*.c, *.s) root directory | `$(T)_DIR/src` | Note that this must be the root folder. Only a single directory is valid. |
 | `$(T)_INC_DIRS` | Modify the directories to search for headers in. | `$(T)_DIR/inc` | This may be any number of directories. |
 | `$(T)_SRC` | Define the source files to compile. | `$(T)_DIR/src/[$(PLATFORM)/]*.(c,s)` | |

--- a/project/README.md
+++ b/project/README.md
@@ -1,0 +1,44 @@
+# Projects
+
+Projects are stored in this directory. Each folder represents an individual project, identified by the folder's name and the existance of a `rules.mk` in the folder's root.
+
+This is an example of a standard project's structure.
+````
+plutus
+├── inc
+│   └── crc15.h
+├── rules.mk
+├── src
+│   ├── crc15.c
+│   └── main.c
+└── test
+    └── test_crc15.c
+
+3 directories, 5 files
+````
+
+## src/inc
+
+`src` and `inc` are the default locations for source and header files respectively. The build system expects a flat folder. That is, it will not search for files recursively unless redefined in `rules.mk`.
+
+To support platform-specific files, we define platform folders. Currently, those are `stm32f0xx` and `x86`. The build system expects platform folders to be either `src/$(PLATFORM)` or `inc/$(PLATFORM)`. Files in these platform-specific folders will only be included when that platform is built.
+
+## test
+
+Unit tests should be located in the `test` subdirectory. Tests are built using [Unity](https://github.com/ThrowTheSwitch/Unity) as a backend. Tests should be named `test_[module name].c` and include `setup_test(void)` and `teardown_test(void)`. `setup_test` is run before each test and `teardown_test` is run after each test. Each function `test_[module name]_[test name](void)` defines an individual unit test.
+
+## rules.mk
+
+`rules.mk` specifies a project's dependencies, flags, and allows for non-standard sources. The build system relies on the existence of `rules.mk` within a project's root to identify valid projects.
+
+### Currently recognized variables
+
+| Variable | Purpose | Default Value | Notes |
+|----------|---------|---------------|-------|
+| `$(T)_DEPS` | Define the libraries that this target depends on. | | A common depedency for projects is `ms-common`, which is our HAL. |
+| `$(T)_SRC_ROOT` | Modify the source file (*.c, *.s) root directory | `$(T)_DIR/src` | Note that this must be the root folder. Only a single directory is valid. |
+| `$(T)_INC_DIRS` | Modify the directories to search for headers in. | `$(T)_DIR/inc` | This may be any number of directories. |
+| `$(T)_SRC` | Define the source files to compile. | `$(T)_DIR/src/[$(PLATFORM)/]*.(c,s)` | |
+| `$(T)_INC` | Define the headers that should be watched. | `$(T)_DIR/inc/*.h` | |
+| `$(T)_CFLAGS` | Define custom target CFLAGS. | `$(CFLAGS)` | |
+| `$(T)_EXCLUDE_TESTS` | Define any tests that should be excluded. | | When specifying tests to exclude, do not include `test_`. |

--- a/project/README.md
+++ b/project/README.md
@@ -39,6 +39,5 @@ Unit tests should be located in the `test` subdirectory. Tests are built using [
 | `$(T)_SRC_ROOT` | Modify the source file (*.c, *.s) root directory | `$(T)_DIR/src` | Note that this must be the root folder. Only a single directory is valid. |
 | `$(T)_INC_DIRS` | Modify the directories to search for headers in. | `$(T)_DIR/inc` | This may be any number of directories. |
 | `$(T)_SRC` | Define the source files to compile. | `$(T)_DIR/src/[$(PLATFORM)/]*.(c,s)` | |
-| `$(T)_INC` | Define the headers that should be watched. | `$(T)_DIR/inc/*.h` | |
 | `$(T)_CFLAGS` | Define custom target CFLAGS. | `$(CFLAGS)` | |
 | `$(T)_EXCLUDE_TESTS` | Define any tests that should be excluded. | | When specifying tests to exclude, do not include `test_`. |

--- a/project/plutus/rules.mk
+++ b/project/plutus/rules.mk
@@ -1,4 +1,5 @@
 # Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
 # $(T)_INC_DIRS: $(T)_DIR/inc

--- a/project/plutus/rules.mk
+++ b/project/plutus/rules.mk
@@ -2,9 +2,8 @@
 # Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM}}/*.{c,s}
-# $(T)_INC: $(T)_DIR/inc{/$(PLATFORM}}/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # Specify the device library you want to include
 $(T)_DEPS := ms-common

--- a/project/queue/rules.mk
+++ b/project/queue/rules.mk
@@ -1,4 +1,5 @@
 # Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
 # $(T)_INC_DIRS: $(T)_DIR/inc

--- a/project/queue/rules.mk
+++ b/project/queue/rules.mk
@@ -2,9 +2,8 @@
 # Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM}}/*.{c,s}
-# $(T)_INC: $(T)_DIR/inc{/$(PLATFORM}}/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # Specify the device library you want to include
 $(T)_DEPS := ms-common

--- a/project/test_project/rules.mk
+++ b/project/test_project/rules.mk
@@ -1,4 +1,5 @@
 # Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
 # $(T)_INC_DIRS: $(T)_DIR/inc

--- a/project/test_project/rules.mk
+++ b/project/test_project/rules.mk
@@ -2,9 +2,8 @@
 # Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
 # Pre-defined:
 # $(T)_SRC_ROOT: $(T)_DIR/src
-# $(T)_INC_DIRS: $(T)_DIR/inc
-# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM}}/*.{c,s}
-# $(T)_INC: $(T)_DIR/inc{/$(PLATFORM}}/*.h
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
 # Specify the device library you want to include
 $(T)_DEPS := ms-common


### PR DESCRIPTION
Supports filtering out tests. I plan on using this to exclude tests by checking for the current platform and defining `$(T)_EXCLUDE_TESTS := can can_rx ...`.