### PR TITLE
ELEC-219: Added module dependencies

### DIFF
--- a/libraries/ms-common/inc/adc.h
+++ b/libraries/ms-common/inc/adc.h
@@ -1,7 +1,6 @@
 #pragma once
-
 // Analog to Digital Converter HAL Inteface
-
+// Requires GPIO and interrupts to be initialized.
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/libraries/ms-common/inc/can.h
+++ b/libraries/ms-common/inc/can.h
@@ -1,5 +1,6 @@
 #pragma once
 // CAN application interface
+// Requires soft timers and interrupts to be initialized.
 //
 // Application code should only use functions in this header.
 #include <stdint.h>

--- a/libraries/ms-common/inc/can_ack.h
+++ b/libraries/ms-common/inc/can_ack.h
@@ -1,5 +1,6 @@
 #pragma once
 // CAN ACK handling
+// Requires soft timers and interrupts to be initialized.
 //
 // ACK request objects are provided with critical messages.
 // They define a callback that should be run when the ACK status is updated.

--- a/libraries/ms-common/inc/can_hw.h
+++ b/libraries/ms-common/inc/can_hw.h
@@ -1,5 +1,6 @@
 #pragma once
 // CAN HW Interface
+// Requires interrupts to be initalized.
 //
 // Used to initiate CAN TX and RX directly through the MCU, without any preprocessing or queues.
 // Note that none of our systems currently support more than one CAN interface natively.

--- a/libraries/ms-common/inc/delay.h
+++ b/libraries/ms-common/inc/delay.h
@@ -1,5 +1,6 @@
 #pragma once
 // Delay function library
+// Requires soft timers and interrupts to be initalized.
 //
 // Blocking delay for a fixed period of time. Still allows interrupts to
 // trigger.

--- a/libraries/ms-common/inc/gpio_it.h
+++ b/libraries/ms-common/inc/gpio_it.h
@@ -1,5 +1,6 @@
 #pragma once
-
+// GPIO Interrupt Handlers
+// Requires GPIO and interrupts to be initialized.
 #include <stdint.h>
 
 #include "gpio.h"

--- a/libraries/ms-common/inc/soft_timer.h
+++ b/libraries/ms-common/inc/soft_timer.h
@@ -1,5 +1,6 @@
 #pragma once
-
+// Software-based timers backed by single hardware timer
+// Requires interrupts to be initialized.
 #include <stdbool.h>
 #include <stdint.h>
 

--- a/libraries/ms-common/inc/spi.h
+++ b/libraries/ms-common/inc/spi.h
@@ -1,5 +1,6 @@
 #pragma once
 // Generic blocking SPI driver
+// Requires GPIO to be initialized.
 #include <stddef.h>
 #include "spi_mcu.h"
 #include "gpio.h"

--- a/libraries/ms-common/inc/uart.h
+++ b/libraries/ms-common/inc/uart.h
@@ -1,5 +1,8 @@
-// Non-blocking UART driver
 #pragma once
+// Non-blocking UART driver
+// Requires GPIO and interrupts to be initialized.
+
+// Uses internal FIFOs to buffer RX and TX.
 #include <stdint.h>
 #include "uart_mcu.h"
 #include "gpio.h"

--- a/libraries/ms-common/src/stm32f0xx/can_hw.c
+++ b/libraries/ms-common/src/stm32f0xx/can_hw.c
@@ -1,5 +1,6 @@
 #include "can_hw.h"
 #include "stm32f0xx.h"
+#include "interrupt.h"
 
 #define CAN_HW_PRESCALER 12
 
@@ -14,12 +15,7 @@ StatusCode can_hw_init(CANHwConfig *can_hw, uint16_t bus_speed, bool loopback) {
 
   s_can = can_hw;
 
-  NVIC_InitTypeDef nvic_cfg = {
-    .NVIC_IRQChannel = CEC_CAN_IRQn,
-    .NVIC_IRQChannelPriority = 0,
-    .NVIC_IRQChannelCmd = ENABLE
-  };
-  NVIC_Init(&nvic_cfg);
+  stm32f0xx_interrupt_nvic_enable(CEC_CAN_IRQn, INTERRUPT_PRIORITY_HIGH);
 
   RCC_APB1PeriphClockCmd(RCC_APB1Periph_CAN, ENABLE);
 

--- a/libraries/ms-common/test/test_can_hw.c
+++ b/libraries/ms-common/test/test_can_hw.c
@@ -2,6 +2,7 @@
 #include "log.h"
 #include "unity.h"
 #include "test_helpers.h"
+#include "interrupt.h"
 
 static CANHwConfig s_can;
 static volatile size_t s_msg_rx;
@@ -23,6 +24,7 @@ static void prv_wait_rx(size_t wait_for) {
 }
 
 void setup_test(void) {
+  interrupt_init();
   can_hw_init(&s_can, 250, true);
   can_hw_register_callback(&s_can, CAN_HW_EVENT_MSG_RX, prv_handle_rx, NULL);
   s_msg_rx = 0;


### PR DESCRIPTION
Turns out most modules just rely on interrupts, GPIO, and soft timers to be initialized.
I also switched CAN to use the interrupt module.