### PR TITLE
ELEC-259: Documentation Improvements and Const Correctness in Interfaces

### DIFF
--- a/libraries/STM32F0xx_StdPeriph_Driver/inc/stm32f0xx_interrupt.h
+++ b/libraries/STM32F0xx_StdPeriph_Driver/inc/stm32f0xx_interrupt.h
@@ -13,7 +13,7 @@ void stm32f0xx_interrupt_init(void);
 StatusCode stm32f0xx_interrupt_nvic_enable(uint8_t irq_channel, InterruptPriority priority);
 
 // Enables the external interrupt line with the given settings.
-StatusCode stm32f0xx_interrupt_exti_enable(uint8_t line, InterruptSettings *settings,
+StatusCode stm32f0xx_interrupt_exti_enable(uint8_t line, const InterruptSettings *settings,
                                            InterruptEdge edge);
 
 // Triggers a software interrupt on a given external interrupt.

--- a/libraries/STM32F0xx_StdPeriph_Driver/src/stm32f0xx_interrupt.c
+++ b/libraries/STM32F0xx_StdPeriph_Driver/src/stm32f0xx_interrupt.c
@@ -45,7 +45,7 @@ StatusCode stm32f0xx_interrupt_nvic_enable(uint8_t irq_channel, InterruptPriorit
   return STATUS_CODE_OK;
 }
 
-StatusCode stm32f0xx_interrupt_exti_enable(uint8_t line, InterruptSettings *settings,
+StatusCode stm32f0xx_interrupt_exti_enable(uint8_t line, const InterruptSettings *settings,
                                            InterruptEdge edge) {
   if (line >= NUM_STM32F0XX_INTERRUPT_LINES || settings->type >= NUM_INTERRUPT_TYPE ||
       edge >= NUM_INTERRUPT_EDGE) {

--- a/libraries/libcore/inc/status.h
+++ b/libraries/libcore/inc/status.h
@@ -3,9 +3,9 @@
 //
 // Usage:
 // Use this library in any function where an error could occur. A verbose error will improve
-// debugability and allow for logging and attempts at recovery.
+// debug-ability and allow for logging and attempts at recovery.
 //
-// If an error has occured in a function that returns a StatusCode then:
+// If an error has occurred in a function that returns a StatusCode then:
 // return status_code(SomeStatusCode);
 // OR
 // return status_msg(SomeStatusCode, "error message");
@@ -66,7 +66,7 @@ typedef void (*status_callback)(const Status* status);
 
 // Updates a status struct containing an error code and optionally a message. This should only be
 // called via the macros.
-StatusCode status_impl_update(const StatusCode code, const char* source, const char* caller,
+StatusCode status_impl_update(StatusCode code, const char* source, const char* caller,
                               const char* message);
 
 // Get a copy of the global status so it can be used safely.

--- a/libraries/ms-common/inc/can_hw.h
+++ b/libraries/ms-common/inc/can_hw.h
@@ -1,6 +1,6 @@
 #pragma once
 // CAN HW Interface
-// Requires interrupts to be initalized.
+// Requires interrupts to be initialized.
 //
 // Used to initiate CAN TX and RX directly through the MCU, without any preprocessing or queues.
 // Note that none of our systems currently support more than one CAN interface natively.
@@ -33,7 +33,7 @@ typedef enum {
 
 typedef struct CANHwConfig {
   CANHwBase base;
-  uint16_t bus_speed; // in kbps
+  uint16_t bus_speed;  // in kbps
   uint8_t num_filters;
   bool loopback;
   CANHwEventHandler handlers[NUM_CAN_HW_EVENTS];

--- a/libraries/ms-common/inc/critical_section.h
+++ b/libraries/ms-common/inc/critical_section.h
@@ -1,4 +1,5 @@
 #pragma once
+// Critical sections to protect code that should not be interrupted.
 
 #include <stdbool.h>
 
@@ -8,15 +9,15 @@
 // bool disabled = critical_section_start();
 // // Critical code here.
 // critical_section_end(disabled);
-// ...
+// // ...
 //
-// This will also protect nested attempts from enabling and disabling interupts from prematurely
+// This will also protect nested attempts from enabling and disabling interrupts from prematurely
 // ending the critical section.
 
-// Disables all interrupts accross all lines/inputs. Returns true if the function disabled
+// Disables all interrupts across all lines/inputs. Returns true if the function disabled
 // interrupts.
 bool critical_section_start(void);
 
-// Enables all registered interrupts on all line/inputs. Passing true to this can be used to
-// forcibly end all critical sections.
+// Enables all registered interrupts on all lines/inputs. Passing true to this function can be used
+// to forcibly end all critical sections.
 void critical_section_end(bool disabled_in_scope);

--- a/libraries/ms-common/inc/delay.h
+++ b/libraries/ms-common/inc/delay.h
@@ -5,7 +5,9 @@
 // Blocking delay for a fixed period of time. Still allows interrupts to
 // trigger.
 //
-// Max allowable time is UINT32_MAX in microseconds.
+// Max allowable time is UINT32_MAX in microseconds (4294.967295 seconds).
+// If a longer duration is needed, check the condition you are waiting on in a loop and then call
+// this function again if the condition is not met.
 
 #include <stdint.h>
 

--- a/libraries/ms-common/inc/event_queue.h
+++ b/libraries/ms-common/inc/event_queue.h
@@ -1,7 +1,7 @@
 #pragma once
 // Global event queue
 //
-// Uses a minimum priority queue to prioritize events of lower ID. Only one instance exists.
+// Uses a minimum priority queue to prioritize events of lower ID. Only one global instance exists.
 #include <stdint.h>
 
 #include "objpool.h"

--- a/libraries/ms-common/inc/fsm.h
+++ b/libraries/ms-common/inc/fsm.h
@@ -25,8 +25,10 @@
 // }
 //
 // Use fsm_state_init to set a state's output function (called whenever transitioned to).
+
 #include <stdbool.h>
 #include <stdint.h>
+
 #include "event_queue.h"
 #include "fsm_impl.h"
 

--- a/libraries/ms-common/inc/gpio.h
+++ b/libraries/ms-common/inc/gpio.h
@@ -15,7 +15,7 @@ typedef struct GPIOAddress {
 typedef enum {
   GPIO_DIR_IN = 0,
   GPIO_DIR_OUT,
-  GPIO_DIR_OUT_OD, // Output open-drain
+  GPIO_DIR_OUT_OD,  // Output open-drain
   NUM_GPIO_DIR,
 } GPIODir;
 
@@ -34,7 +34,9 @@ typedef enum {
   NUM_GPIO_RES,
 } GPIORes;
 
-// For setting the alternate function on the pin
+// For setting the alternate function on the pin. The specific meaning of each depends on the
+// architecture and platform refer to the datasheet for the stm32f0xx for specifics. Not
+// implemented on x86.
 typedef enum {
   GPIO_ALTFN_NONE = 0,
   GPIO_ALTFN_0,
@@ -57,20 +59,18 @@ typedef struct GPIOSettings {
   GPIOAltFn alt_function;
 } GPIOSettings;
 
-// All the following functions return true if the operation was successful and false otherwise.
-
 // Initializes GPIO globally by setting all pins to their default state. ONLY CALL ONCE or it will
 // deinit all current settings. Change setting by calling gpio_init_pin.
 StatusCode gpio_init(void);
 
 // Initializes a GPIO pin by address.
-StatusCode gpio_init_pin(GPIOAddress *address, GPIOSettings *settings);
+StatusCode gpio_init_pin(const GPIOAddress *address, const GPIOSettings *settings);
 
 // Set the pin state by address.
-StatusCode gpio_set_pin_state(GPIOAddress *address, GPIOState state);
+StatusCode gpio_set_pin_state(const GPIOAddress *address, GPIOState state);
 
 // Toggles the output state of the pin.
-StatusCode gpio_toggle_state(GPIOAddress *address);
+StatusCode gpio_toggle_state(const GPIOAddress *address);
 
 // Gets the value of the input register for a pin and assigns it to the state that is passed in.
-StatusCode gpio_get_value(GPIOAddress *address, GPIOState *input_state);
+StatusCode gpio_get_value(const GPIOAddress *address, GPIOState *input_state);

--- a/libraries/ms-common/inc/gpio_it.h
+++ b/libraries/ms-common/inc/gpio_it.h
@@ -13,8 +13,8 @@ typedef void (*gpio_it_callback)(GPIOAddress *address, void *context);
 void gpio_it_init(void);
 
 // Registers a new callback on a given port pin combination with the desired settings.
-StatusCode gpio_it_register_interrupt(GPIOAddress *address, InterruptSettings *settings,
+StatusCode gpio_it_register_interrupt(const GPIOAddress *address, const InterruptSettings *settings,
                                       InterruptEdge edge, gpio_it_callback callback, void *context);
 
 // Triggers an interrupt in software.
-StatusCode gpio_it_trigger_interrupt(GPIOAddress *address);
+StatusCode gpio_it_trigger_interrupt(const GPIOAddress *address);

--- a/libraries/ms-common/inc/gpio_it.h
+++ b/libraries/ms-common/inc/gpio_it.h
@@ -7,7 +7,7 @@
 #include "interrupt_def.h"
 #include "status.h"
 
-typedef void (*gpio_it_callback)(GPIOAddress *address, void *context);
+typedef void (*gpio_it_callback)(const GPIOAddress *address, void *context);
 
 // Initializes the interrupt handler for GPIO.
 void gpio_it_init(void);

--- a/libraries/ms-common/inc/interrupt.h
+++ b/libraries/ms-common/inc/interrupt.h
@@ -2,6 +2,6 @@
 // Interrupt initiation module which calls the appropriate setups for each architecture.
 
 // Initializes interrupts. Call before any interrupts are added, will reset interrupts if called
-// multiple times requiring re-intialization of all interrupt modules followed by re-registering all
-// interrupts.
+// multiple times requiring re-initialization of all interrupt modules followed by re-registering
+// all interrupts.
 void interrupt_init(void);

--- a/libraries/ms-common/inc/log.h
+++ b/libraries/ms-common/inc/log.h
@@ -1,4 +1,9 @@
 #pragma once
+// General logging functions.
+// Logging is done via printf which retargets to UART by default on stm32f0xx.
+//
+// Best practice is to use log level WARNING for recoverable faults and CRITICAL for irrecoverable
+// faults. DEBUG can be used for anything.
 #include <stdio.h>
 
 typedef enum {
@@ -16,11 +21,11 @@ typedef enum {
 
 #define LOG_DEBUG(fmt, ...) LOG(LOG_LEVEL_DEBUG, fmt, ##__VA_ARGS__)
 #define LOG_WARN(fmt, ...) LOG(LOG_LEVEL_WARN, fmt, ##__VA_ARGS__)
-#define LOG_FAULT(fmt, ...) LOG(LOG_LEVEL_FAULT, fmt, ##__VA_ARGS__)
+#define LOG_CRITICAL(fmt, ...) LOG(LOG_LEVEL_CRITICAL, fmt, ##__VA_ARGS__)
 
-#define LOG(level, fmt, ...) \
-do { \
-  if ((level) >= LOG_LEVEL_VERBOSITY) { \
-    printf("[%d] %s:%d: " fmt, (level), __FILE__, __LINE__, ##__VA_ARGS__); \
-  } \
-} while (0)
+#define LOG(level, fmt, ...)                                                  \
+  do {                                                                        \
+    if ((level) >= LOG_LEVEL_VERBOSITY) {                                     \
+      printf("[%d] %s:%d: " fmt, (level), __FILE__, __LINE__, ##__VA_ARGS__); \
+    }                                                                         \
+  } while (0)

--- a/libraries/ms-common/inc/spi.h
+++ b/libraries/ms-common/inc/spi.h
@@ -2,15 +2,15 @@
 // Generic blocking SPI driver
 // Requires GPIO to be initialized.
 #include <stddef.h>
-#include "spi_mcu.h"
 #include "gpio.h"
+#include "spi_mcu.h"
 #include "status.h"
 
 typedef enum {
-  SPI_MODE_0 = 0, // CPOL: 0 CPHA: 0
-  SPI_MODE_1,     // CPOL: 0 CPHA: 1
-  SPI_MODE_2,     // CPOL: 1 CPHA: 0
-  SPI_MODE_3      // CPOL: 1 CPHA: 1
+  SPI_MODE_0 = 0,  // CPOL: 0 CPHA: 0
+  SPI_MODE_1,      // CPOL: 0 CPHA: 1
+  SPI_MODE_2,      // CPOL: 1 CPHA: 0
+  SPI_MODE_3       // CPOL: 1 CPHA: 1
 } SPIMode;
 
 typedef struct {
@@ -23,7 +23,7 @@ typedef struct {
   GPIOAddress cs;
 } SPISettings;
 
-StatusCode spi_init(SPIPort spi, SPISettings *settings);
+StatusCode spi_init(SPIPort spi, const SPISettings *settings);
 
-StatusCode spi_exchange(SPIPort spi, uint8_t *tx_data, size_t tx_len,
-                        uint8_t *rx_data, size_t rx_len);
+StatusCode spi_exchange(SPIPort spi, uint8_t *tx_data, size_t tx_len, uint8_t *rx_data,
+                        size_t rx_len);

--- a/libraries/ms-common/inc/test_helpers.h
+++ b/libraries/ms-common/inc/test_helpers.h
@@ -1,12 +1,15 @@
 #pragma once
+// Test helper functions. These should only ever be called within a file in the test folder.
 
 #include <stdint.h>
 
 #include "status.h"
 #include "unity.h"
 
+// General use:
 #define TEST_ASSERT_OK(code) TEST_ASSERT_EQUAL(STATUS_CODE_OK, (code))
 #define TEST_ASSERT_NOT_OK(code) TEST_ASSERT_NOT_EQUAL(STATUS_CODE_OK, (code))
 
+// For testing soft_timer.h:
 // TEST ONLY FUNCTION TO SET TIMER COUNTER FOR SOFT TIMERS UNSAFE TO CALL OUTSIDE A TEST.
 void _test_soft_timer_set_counter(uint32_t counter_value);

--- a/libraries/ms-common/inc/wait.h
+++ b/libraries/ms-common/inc/wait.h
@@ -1,5 +1,5 @@
 #pragma once
 // Wait module
 
-// Wait until an interrupt event occurs or a debug instruction is sent.
+// Blocks until an interrupt occurs or a debug instruction is sent.
 void wait(void);

--- a/libraries/ms-common/src/stm32f0xx/gpio.c
+++ b/libraries/ms-common/src/stm32f0xx/gpio.c
@@ -32,12 +32,11 @@ static bool prv_are_settings_valid(const GPIOSettings *settings) {
            settings->resistor >= NUM_GPIO_RES || settings->alt_function >= NUM_GPIO_ALTFN);
 }
 
-
 StatusCode gpio_init(void) {
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_init_pin(GPIOAddress *address, GPIOSettings *settings) {
+StatusCode gpio_init_pin(const GPIOAddress *address, const GPIOSettings *settings) {
   if (!prv_is_address_valid(address) || !prv_are_settings_valid(settings)) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
@@ -75,7 +74,7 @@ StatusCode gpio_init_pin(GPIOAddress *address, GPIOSettings *settings) {
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_set_pin_state(GPIOAddress *address, GPIOState state) {
+StatusCode gpio_set_pin_state(const GPIOAddress *address, GPIOState state) {
   if (!prv_is_address_valid(address) || !prv_is_state_valid(&state)) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
@@ -84,7 +83,7 @@ StatusCode gpio_set_pin_state(GPIOAddress *address, GPIOState state) {
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_toggle_state(GPIOAddress *address) {
+StatusCode gpio_toggle_state(const GPIOAddress *address) {
   if (!prv_is_address_valid(address)) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
@@ -99,7 +98,7 @@ StatusCode gpio_toggle_state(GPIOAddress *address) {
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_get_value(GPIOAddress *address, GPIOState *input_state) {
+StatusCode gpio_get_value(const GPIOAddress *address, GPIOState *input_state) {
   if (!prv_is_address_valid(address)) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }

--- a/libraries/ms-common/src/stm32f0xx/gpio_it.c
+++ b/libraries/ms-common/src/stm32f0xx/gpio_it.c
@@ -5,8 +5,8 @@
 
 #include "gpio.h"
 #include "interrupt_def.h"
-#include "stm32f0xx_interrupt.h"
 #include "status.h"
+#include "stm32f0xx_interrupt.h"
 #include "stm32f0xx_syscfg.h"
 
 typedef struct GPIOITInterrupt {
@@ -34,7 +34,7 @@ static uint8_t prv_get_irq_channel(uint8_t pin) {
   return 7;
 }
 
-StatusCode gpio_it_register_interrupt(GPIOAddress *address, InterruptSettings *settings,
+StatusCode gpio_it_register_interrupt(const GPIOAddress *address, const InterruptSettings *settings,
                                       InterruptEdge edge, gpio_it_callback callback,
                                       void *context) {
   if (address->port >= GPIO_MCU_NUM_PORTS || address->pin >= GPIO_MCU_NUM_PINS_PER_PORT) {
@@ -65,7 +65,7 @@ StatusCode gpio_it_register_interrupt(GPIOAddress *address, InterruptSettings *s
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_it_trigger_interrupt(GPIOAddress *address) {
+StatusCode gpio_it_trigger_interrupt(const GPIOAddress *address) {
   if (address->port >= GPIO_MCU_NUM_PORTS || address->pin >= GPIO_MCU_NUM_PINS_PER_PORT) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }

--- a/libraries/ms-common/src/stm32f0xx/spi.c
+++ b/libraries/ms-common/src/stm32f0xx/spi.c
@@ -10,19 +10,17 @@ typedef struct {
 } SPIPortData;
 
 static SPIPortData s_port[SPI_MCU_NUM_PORTS] = {
-  {
-    .rcc_cmd = RCC_APB2PeriphClockCmd,
-    .periph = RCC_APB2Periph_SPI1,
-    .base = SPI1
+  { .rcc_cmd = RCC_APB2PeriphClockCmd,
+  	.periph = RCC_APB2Periph_SPI1,
+  	.base = SPI1
   },
-  {
-    .rcc_cmd = RCC_APB1PeriphClockCmd,
-    .periph = RCC_APB1Periph_SPI2,
-    .base = SPI2
+  { .rcc_cmd = RCC_APB1PeriphClockCmd,
+  	.periph = RCC_APB1Periph_SPI2,
+  	.base = SPI2
   }
 };
 
-StatusCode spi_init(SPIPort spi, SPISettings *settings) {
+StatusCode spi_init(SPIPort spi, const SPISettings *settings) {
   RCC_ClocksTypeDef clocks;
   RCC_GetClocksFreq(&clocks);
 
@@ -49,17 +47,15 @@ StatusCode spi_init(SPIPort spi, SPISettings *settings) {
   gpio_settings.alt_function = GPIO_ALTFN_NONE;
   gpio_init_pin(&settings->cs, &gpio_settings);
 
-  SPI_InitTypeDef init = {
-    .SPI_Direction = SPI_Direction_2Lines_FullDuplex,
-    .SPI_Mode = SPI_Mode_Master,
-    .SPI_DataSize = SPI_DataSize_8b,
-    .SPI_CPHA = (settings->mode & 0x01) ? SPI_CPHA_2Edge : SPI_CPHA_1Edge,
-    .SPI_CPOL = (settings->mode & 0x02) ? SPI_CPOL_High : SPI_CPOL_Low,
-    .SPI_NSS = SPI_NSS_Soft,
-    .SPI_BaudRatePrescaler = (index - 2) << 3,
-    .SPI_FirstBit = SPI_FirstBit_MSB,
-    .SPI_CRCPolynomial = 7
-  };
+  SPI_InitTypeDef init = { .SPI_Direction = SPI_Direction_2Lines_FullDuplex,
+                           .SPI_Mode = SPI_Mode_Master,
+                           .SPI_DataSize = SPI_DataSize_8b,
+                           .SPI_CPHA = (settings->mode & 0x01) ? SPI_CPHA_2Edge : SPI_CPHA_1Edge,
+                           .SPI_CPOL = (settings->mode & 0x02) ? SPI_CPOL_High : SPI_CPOL_Low,
+                           .SPI_NSS = SPI_NSS_Soft,
+                           .SPI_BaudRatePrescaler = (index - 2) << 3,
+                           .SPI_FirstBit = SPI_FirstBit_MSB,
+                           .SPI_CRCPolynomial = 7 };
   SPI_Init(s_port[spi].base, &init);
 
   // Set the RX threshold to 1 byte
@@ -70,8 +66,8 @@ StatusCode spi_init(SPIPort spi, SPISettings *settings) {
   return STATUS_CODE_OK;
 }
 
-StatusCode spi_exchange(SPIPort spi, uint8_t *tx_data, size_t tx_len,
-                        uint8_t *rx_data, size_t rx_len) {
+StatusCode spi_exchange(SPIPort spi, uint8_t *tx_data, size_t tx_len, uint8_t *rx_data,
+                        size_t rx_len) {
   gpio_set_pin_state(&s_port[spi].cs, GPIO_STATE_LOW);
 
   for (int i = 0; i < tx_len; i++) {

--- a/libraries/ms-common/src/stm32f0xx/spi.c
+++ b/libraries/ms-common/src/stm32f0xx/spi.c
@@ -10,11 +10,13 @@ typedef struct {
 } SPIPortData;
 
 static SPIPortData s_port[SPI_MCU_NUM_PORTS] = {
-  { .rcc_cmd = RCC_APB2PeriphClockCmd,
+  {
+    .rcc_cmd = RCC_APB2PeriphClockCmd,
     .periph = RCC_APB2Periph_SPI1,
     .base = SPI1
   },
-  { .rcc_cmd = RCC_APB1PeriphClockCmd,
+  {
+    .rcc_cmd = RCC_APB1PeriphClockCmd,
     .periph = RCC_APB1Periph_SPI2,
     .base = SPI2
   }
@@ -47,15 +49,17 @@ StatusCode spi_init(SPIPort spi, const SPISettings *settings) {
   gpio_settings.alt_function = GPIO_ALTFN_NONE;
   gpio_init_pin(&settings->cs, &gpio_settings);
 
-  SPI_InitTypeDef init = { .SPI_Direction = SPI_Direction_2Lines_FullDuplex,
-                           .SPI_Mode = SPI_Mode_Master,
-                           .SPI_DataSize = SPI_DataSize_8b,
-                           .SPI_CPHA = (settings->mode & 0x01) ? SPI_CPHA_2Edge : SPI_CPHA_1Edge,
-                           .SPI_CPOL = (settings->mode & 0x02) ? SPI_CPOL_High : SPI_CPOL_Low,
-                           .SPI_NSS = SPI_NSS_Soft,
-                           .SPI_BaudRatePrescaler = (index - 2) << 3,
-                           .SPI_FirstBit = SPI_FirstBit_MSB,
-                           .SPI_CRCPolynomial = 7 };
+  SPI_InitTypeDef init = {
+    .SPI_Direction = SPI_Direction_2Lines_FullDuplex,
+    .SPI_Mode = SPI_Mode_Master,
+    .SPI_DataSize = SPI_DataSize_8b,
+    .SPI_CPHA = (settings->mode & 0x01) ? SPI_CPHA_2Edge : SPI_CPHA_1Edge,
+    .SPI_CPOL = (settings->mode & 0x02) ? SPI_CPOL_High : SPI_CPOL_Low,
+    .SPI_NSS = SPI_NSS_Soft,
+    .SPI_BaudRatePrescaler = (index - 2) << 3,
+    .SPI_FirstBit = SPI_FirstBit_MSB,
+    .SPI_CRCPolynomial = 7
+  };
   SPI_Init(s_port[spi].base, &init);
 
   // Set the RX threshold to 1 byte

--- a/libraries/ms-common/src/stm32f0xx/spi.c
+++ b/libraries/ms-common/src/stm32f0xx/spi.c
@@ -11,12 +11,12 @@ typedef struct {
 
 static SPIPortData s_port[SPI_MCU_NUM_PORTS] = {
   { .rcc_cmd = RCC_APB2PeriphClockCmd,
-  	.periph = RCC_APB2Periph_SPI1,
-  	.base = SPI1
+    .periph = RCC_APB2Periph_SPI1,
+    .base = SPI1
   },
   { .rcc_cmd = RCC_APB1PeriphClockCmd,
-  	.periph = RCC_APB1Periph_SPI2,
-  	.base = SPI2
+    .periph = RCC_APB1Periph_SPI2,
+    .base = SPI2
   }
 };
 

--- a/libraries/ms-common/src/x86/gpio.c
+++ b/libraries/ms-common/src/x86/gpio.c
@@ -24,15 +24,15 @@ static bool prv_are_settings_valid(const GPIOSettings *settings) {
            settings->resistor >= NUM_GPIO_RES || settings->alt_function >= NUM_GPIO_ALTFN);
 }
 
-static uint32_t prv_get_index(GPIOAddress *address) {
+static uint32_t prv_get_index(const GPIOAddress *address) {
   return address->port * GPIO_MCU_NUM_PORTS + address->pin;
 }
 
 StatusCode gpio_init(void) {
   GPIOSettings default_settings = { .direction = GPIO_DIR_IN,
-                                   .state = GPIO_STATE_LOW,
-                                   .resistor = GPIO_RES_NONE,
-                                   .alt_function = GPIO_ALTFN_NONE };
+                                    .state = GPIO_STATE_LOW,
+                                    .resistor = GPIO_RES_NONE,
+                                    .alt_function = GPIO_ALTFN_NONE };
   for (uint32_t i = 0; i < GPIO_MCU_TOTAL_PINS; i++) {
     s_pin_settings[i] = default_settings;
     s_gpio_pin_input_value[i] = 0;
@@ -40,7 +40,7 @@ StatusCode gpio_init(void) {
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_init_pin(GPIOAddress *address, GPIOSettings *settings) {
+StatusCode gpio_init_pin(const GPIOAddress *address, const GPIOSettings *settings) {
   if (!prv_is_address_valid(address) || !prv_are_settings_valid(settings)) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
@@ -49,7 +49,7 @@ StatusCode gpio_init_pin(GPIOAddress *address, GPIOSettings *settings) {
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_set_pin_state(GPIOAddress *address, GPIOState state) {
+StatusCode gpio_set_pin_state(const GPIOAddress *address, GPIOState state) {
   if (!prv_is_address_valid(address) || !prv_is_state_valid(&state)) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
@@ -58,7 +58,7 @@ StatusCode gpio_set_pin_state(GPIOAddress *address, GPIOState state) {
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_toggle_state(GPIOAddress *address) {
+StatusCode gpio_toggle_state(const GPIOAddress *address) {
   if (!prv_is_address_valid(address)) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
@@ -72,7 +72,7 @@ StatusCode gpio_toggle_state(GPIOAddress *address) {
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_get_value(GPIOAddress *address, GPIOState *state) {
+StatusCode gpio_get_value(const GPIOAddress *address, GPIOState *state) {
   if (!prv_is_address_valid(address)) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }

--- a/libraries/ms-common/src/x86/gpio_it.c
+++ b/libraries/ms-common/src/x86/gpio_it.c
@@ -5,8 +5,8 @@
 
 #include "gpio.h"
 #include "interrupt_def.h"
-#include "x86_interrupt.h"
 #include "status.h"
+#include "x86_interrupt.h"
 
 typedef struct GPIOITInterrupt {
   uint8_t interrupt_id;
@@ -37,7 +37,7 @@ void gpio_it_init(void) {
   }
 }
 
-StatusCode gpio_it_register_interrupt(GPIOAddress *address, InterruptSettings *settings,
+StatusCode gpio_it_register_interrupt(const GPIOAddress *address, const InterruptSettings *settings,
                                       InterruptEdge edge, gpio_it_callback callback,
                                       void *context) {
   if (address->port >= GPIO_MCU_NUM_PORTS || address->pin >= GPIO_MCU_NUM_PINS_PER_PORT) {
@@ -58,7 +58,7 @@ StatusCode gpio_it_register_interrupt(GPIOAddress *address, InterruptSettings *s
   return STATUS_CODE_OK;
 }
 
-StatusCode gpio_it_trigger_interrupt(GPIOAddress *address) {
+StatusCode gpio_it_trigger_interrupt(const GPIOAddress *address) {
   if (address->port >= GPIO_MCU_NUM_PORTS || address->pin >= GPIO_MCU_NUM_PINS_PER_PORT) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }

--- a/libraries/ms-common/src/x86/spi.c
+++ b/libraries/ms-common/src/x86/spi.c
@@ -1,10 +1,10 @@
 #include "spi.h"
 
-StatusCode spi_init(SPIPort spi, SPISettings *settings) {
+StatusCode spi_init(SPIPort spi, const SPISettings *settings) {
   return status_code(STATUS_CODE_UNIMPLEMENTED);
 }
 
-StatusCode spi_exchange(SPIPort spi, uint8_t *tx_data, size_t tx_len,
-                        uint8_t *rx_data, size_t rx_len) {
+StatusCode spi_exchange(SPIPort spi, uint8_t *tx_data, size_t tx_len, uint8_t *rx_data,
+                        size_t rx_len) {
   return status_code(STATUS_CODE_UNIMPLEMENTED);
 }

--- a/libraries/ms-common/test/test_gpio_it.c
+++ b/libraries/ms-common/test/test_gpio_it.c
@@ -20,7 +20,7 @@ static InterruptSettings s_event_settings = { .type = INTERRUPT_TYPE_EVENT,
 static volatile bool s_correct_port = false;
 static volatile bool s_interrupt_ran = false;
 
-static void prv_test_callback(GPIOAddress* address, void* context) {
+static void prv_test_callback(const GPIOAddress* address, void* context) {
   if (address->port == 1) {
     s_correct_port = true;
   }

--- a/libraries/x86/inc/x86_interrupt.h
+++ b/libraries/x86/inc/x86_interrupt.h
@@ -16,7 +16,7 @@ void x86_interrupt_init(void);
 StatusCode x86_interrupt_register_handler(x86_interrupt_handler handler, uint8_t* handler_id);
 
 // Registers a callback to a handler assigning it a new id from the global interrupt id pool.
-StatusCode x86_interrupt_register_interrupt(uint8_t handler_id, InterruptSettings* settings,
+StatusCode x86_interrupt_register_interrupt(uint8_t handler_id, const InterruptSettings* settings,
                                             uint8_t* interrupt_id);
 
 // Triggers a software interrupt by interrupt_id.

--- a/libraries/x86/src/x86_interrupt.c
+++ b/libraries/x86/src/x86_interrupt.c
@@ -3,6 +3,7 @@
 #include <signal.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 #include <unistd.h>
 
 #include "interrupt_def.h"
@@ -89,7 +90,7 @@ StatusCode x86_interrupt_register_handler(x86_interrupt_handler handler, uint8_t
   return STATUS_CODE_OK;
 }
 
-StatusCode x86_interrupt_register_interrupt(uint8_t handler_id, InterruptSettings *settings,
+StatusCode x86_interrupt_register_interrupt(uint8_t handler_id, const InterruptSettings *settings,
                                             uint8_t *interrupt_id) {
   if (handler_id >= s_x86_interrupt_next_handler_id ||
       settings->priority >= NUM_INTERRUPT_PRIORITY || settings->type >= NUM_INTERRUPT_TYPE) {


### PR DESCRIPTION
This PR is the first in what will likely be a series of PRs that cleanup the ms-common library prior to the start of the new term.

**Issues addressed in this PR:**
*   "Const Correctness" --- adding the const modifier to places where it is applicable especially in interfaces.
*   Documentation in `*.h` files is lacking in some places. I also fixed any spelling or grammatical errors I found. This is likely to be an ongoing project.

**Issues to consider in a future PR:**
*   Move generic data structures such as objpool, queues and FSM to libcore.
*   Move other generic code such as log to libcore. 

Moving things to libcore will entail keeping their tests in ms-common or in a new library of just tests for libcore. This is because the tests need to be built after the platform libs are built hence why I am hesitant to outright move everything to it immediately.

Suggestions on other possible improvements are welcome :)