### PR TITLE
ELEC-263: Improve PWM module by supporting different hardware timers.

### DIFF
--- a/libraries/ms-common/inc/pwm.h
+++ b/libraries/ms-common/inc/pwm.h
@@ -1,31 +1,27 @@
 #pragma once
-// PWM Library
-//
+// PWM Module
+
 // Usage Notes:
-// - Module must be initialized before use.
+// - Module must be initialized for the timer you want before use.
 // - Use pwm_set_dc unless you have reason not to.
-// - pwm_set_pulse affords resolution < 1% of the duty cycle.
-// - For stm32f0xx GPIO pins must use the correct GPIO_ALTFN to utilize the PWM.
-//
-// Implementation Detail:
-// - This only enables PWM on channels tied to TIM3 all using the same duty cycle. This may need to
-// be altered as not all PWM devices may use this timer. Additionally, each channel (4) of TIM3 may
-// want its own pulse width. For the purposes of simplicity this will be left as is for now but may
-// need revision in future.
+// - pwm_set_pulse affords resolution < 1% unlike pwm_set_dc.
+// - For stm32f0xx GPIO pins must use the correct GPIO_ALTFN to utilize the PWM (See Datasheet).
+// - On stm32f0xx all PWM channels for a timer are automatically connected.
 
 #include <stdint.h>
 
+#include "pwm_mcu.h"
 #include "status.h"
 
-// Initializes the PWM with a period in milliseconds.
-StatusCode pwm_init(uint16_t period_ms);
+// Initializes the PWM for a set timer with a period in milliseconds.
+StatusCode pwm_init(PWMTimer timer, uint16_t period_ms);
 
-// Gets the current period of the PWM.
-uint16_t pwm_get_period(void);
+// Gets the current period of a specified PWM timer.
+uint16_t pwm_get_period(PWMTimer timer);
 
-// Sets the pulse width in ms of the PWM. Use for high resolution control.
-StatusCode pwm_set_pulse(uint16_t pulse_width_ms);
+// Sets the pulse width in ms of the PWM timer. Use for high resolution control.
+StatusCode pwm_set_pulse(PWMTimer timer, uint16_t pulse_width_ms);
 
-// Sets the duty cycle, in units of 1%, of the PWM. This wraps the
-// pwm_set_pulse doing the necessary math.
-StatusCode pwm_set_dc(uint16_t dc);
+// Sets the duty cycle, in units of 1%, of the PWM timer. This wraps pwm_set_pulse doing the
+// necessary math to convert from 0-100% to the fraction of the period.
+StatusCode pwm_set_dc(PWMTimer timer, uint16_t dc);

--- a/libraries/ms-common/inc/stm32f0xx/pwm_mcu.h
+++ b/libraries/ms-common/inc/stm32f0xx/pwm_mcu.h
@@ -1,0 +1,14 @@
+#pragma once
+
+// Not all timers on the stm32f0xx support PWM mode these are the ones that do.
+// The number comes from the id of the hardware timer.
+typedef enum {
+  PWM_TIMER_1 = 0,
+  // PWM_TIMER_2,  // Requisitioned to back the soft_timer module.
+  PWM_TIMER_3,
+  PWM_TIMER_14,
+  PWM_TIMER_15,
+  PWM_TIMER_16,
+  PWM_TIMER_17,
+  NUM_PWM_TIMERS,
+} PWMTimer;

--- a/libraries/ms-common/inc/x86/pwm_mcu.h
+++ b/libraries/ms-common/inc/x86/pwm_mcu.h
@@ -1,0 +1,5 @@
+#pragma once
+
+typedef enum {
+  NUM_PWM_TIMERS = 0,
+} PWMTimer;

--- a/libraries/ms-common/rules.mk
+++ b/libraries/ms-common/rules.mk
@@ -8,5 +8,5 @@
 $(T)_DEPS := $(PLATFORM_LIB) libcore
 
 ifeq (x86,$(PLATFORM))
-$(T)_EXCLUDE_TESTS := can can_hw adc
+$(T)_EXCLUDE_TESTS := can can_hw adc pwm
 endif

--- a/libraries/ms-common/src/delay.c
+++ b/libraries/ms-common/src/delay.c
@@ -7,7 +7,7 @@
 #include "wait.h"
 
 static void prv_delay_it(SoftTimerID timer_id, void *context) {
-  bool *block = context;
+  volatile bool *block = context;
   *block = false;
 }
 

--- a/libraries/ms-common/src/stm32f0xx/pwm.c
+++ b/libraries/ms-common/src/stm32f0xx/pwm.c
@@ -3,19 +3,69 @@
 #include <stdint.h>
 
 #include "gpio.h"
+#include "pwm_mcu.h"
 #include "stm32f0xx_rcc.h"
 #include "stm32f0xx_tim.h"
 
-static uint16_t s_period_ms = 0;
+static uint16_t s_period_ms[NUM_PWM_TIMERS] = {
+      [PWM_TIMER_1] = 0,   //
+      [PWM_TIMER_3] = 0,   //
+      [PWM_TIMER_14] = 0,  //
+      [PWM_TIMER_15] = 0,  //
+      [PWM_TIMER_16] = 0,  //
+      [PWM_TIMER_17] = 0,  //
+};
 
-StatusCode pwm_init(uint16_t period_ms) {
+static TIM_TypeDef *s_timer_def[NUM_PWM_TIMERS] = {
+      [PWM_TIMER_1] = TIM1,    //
+      [PWM_TIMER_3] = TIM3,    //
+      [PWM_TIMER_14] = TIM14,  //
+      [PWM_TIMER_15] = TIM15,  //
+      [PWM_TIMER_16] = TIM16,  //
+      [PWM_TIMER_17] = TIM17,  //
+};
+
+static StatusCode prv_check_timer_id(PWMTimer timer) {
+  if (timer >= NUM_PWM_TIMERS) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid timer id");
+  }
+  return STATUS_CODE_OK;
+}
+
+static void prv_enable_periph_clock(PWMTimer timer) {
+  switch (timer) {
+    case PWM_TIMER_1:
+      RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM1, ENABLE);
+      return;
+    case PWM_TIMER_3:
+      RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM3, ENABLE);
+      return;
+    case PWM_TIMER_14:
+      RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM14, ENABLE);
+      return;
+    case PWM_TIMER_15:
+      RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM15, ENABLE);
+      return;
+    case PWM_TIMER_16:
+      RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM16, ENABLE);
+      return;
+    case PWM_TIMER_17:
+      RCC_APB2PeriphClockCmd(RCC_APB2Periph_TIM17, ENABLE);
+      return;
+    default:
+      return;
+  }
+}
+
+StatusCode pwm_init(PWMTimer timer, uint16_t period_ms) {
   if (period_ms == 0) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Period must be greater than 0");
   }
+  status_ok_or_return(prv_check_timer_id(timer));
 
-  RCC_APB1PeriphClockCmd(RCC_APB1Periph_TIM3, ENABLE);
+  prv_enable_periph_clock(timer);
 
-  s_period_ms = period_ms;
+  s_period_ms[timer] = period_ms;
 
   RCC_ClocksTypeDef clocks;
   RCC_GetClocksFreq(&clocks);
@@ -28,23 +78,25 @@ StatusCode pwm_init(uint16_t period_ms) {
     .TIM_RepetitionCounter = 0,
   };
 
-  TIM_TimeBaseInit(TIM3, &tim_init);
-  TIM_Cmd(TIM3, ENABLE);
-  TIM_CtrlPWMOutputs(TIM3, ENABLE);
+  TIM_TimeBaseInit(s_timer_def[timer], &tim_init);
+  TIM_Cmd(s_timer_def[timer], ENABLE);
+  TIM_CtrlPWMOutputs(s_timer_def[timer], ENABLE);
 
   return STATUS_CODE_OK;
 }
 
-uint16_t pwm_get_period(void) {
-  return s_period_ms;
+uint16_t pwm_get_period(PWMTimer timer) {
+  status_ok_or_return(prv_check_timer_id(timer));
+  return s_period_ms[timer];
 }
 
-StatusCode pwm_set_pulse(uint16_t pulse_width_ms) {
-  if (s_period_ms == 0) {
+StatusCode pwm_set_pulse(PWMTimer timer, uint16_t pulse_width_ms) {
+  if (s_period_ms[timer] == 0) {
     return status_msg(STATUS_CODE_UNINITIALIZED, "Pwm must be initialized.");
-  } else if (pulse_width_ms > s_period_ms) {
+  } else if (pulse_width_ms > s_period_ms[timer]) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Pulse width must be leq period.");
   }
+  status_ok_or_return(prv_check_timer_id(timer));
 
   TIM_OCInitTypeDef oc_init = {
     .TIM_OCMode = TIM_OCMode_PWM1,  // Set on compare match.
@@ -55,30 +107,31 @@ StatusCode pwm_set_pulse(uint16_t pulse_width_ms) {
 
   // Enable PWM on all channels.
 
-  TIM_OC1Init(TIM3, &oc_init);
-  TIM_OC1PreloadConfig(TIM3, TIM_OCPreload_Enable);
+  TIM_OC1Init(s_timer_def[timer], &oc_init);
+  TIM_OC1PreloadConfig(s_timer_def[timer], TIM_OCPreload_Enable);
 
-  TIM_OC2Init(TIM3, &oc_init);
-  TIM_OC2PreloadConfig(TIM3, TIM_OCPreload_Enable);
+  TIM_OC2Init(s_timer_def[timer], &oc_init);
+  TIM_OC2PreloadConfig(s_timer_def[timer], TIM_OCPreload_Enable);
 
-  TIM_OC3Init(TIM3, &oc_init);
-  TIM_OC3PreloadConfig(TIM3, TIM_OCPreload_Enable);
+  TIM_OC3Init(s_timer_def[timer], &oc_init);
+  TIM_OC3PreloadConfig(s_timer_def[timer], TIM_OCPreload_Enable);
 
-  TIM_OC4Init(TIM3, &oc_init);
-  TIM_OC4PreloadConfig(TIM3, TIM_OCPreload_Enable);
+  TIM_OC4Init(s_timer_def[timer], &oc_init);
+  TIM_OC4PreloadConfig(s_timer_def[timer], TIM_OCPreload_Enable);
 
   return STATUS_CODE_OK;
 }
 
-StatusCode pwm_set_dc(uint16_t dc) {
+StatusCode pwm_set_dc(PWMTimer timer, uint16_t dc) {
   if (dc > 100) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Duty Cycle must be leq 100%.");
   }
+  status_ok_or_return(prv_check_timer_id(timer));
 
   uint16_t pulse_width = 0;
   if (dc != 0) {
-    pulse_width = ((s_period_ms + 1) * dc) / 100 - 1;
+    pulse_width = ((s_period_ms[timer] + 1) * dc) / 100 - 1;
   }
 
-  return pwm_set_pulse(pulse_width);
+  return pwm_set_pulse(timer, pulse_width);
 }

--- a/libraries/ms-common/src/stm32f0xx/pwm.c
+++ b/libraries/ms-common/src/stm32f0xx/pwm.c
@@ -91,12 +91,12 @@ uint16_t pwm_get_period(PWMTimer timer) {
 }
 
 StatusCode pwm_set_pulse(PWMTimer timer, uint16_t pulse_width_ms) {
+  status_ok_or_return(prv_check_timer_id(timer));
   if (s_period_ms[timer] == 0) {
     return status_msg(STATUS_CODE_UNINITIALIZED, "Pwm must be initialized.");
   } else if (pulse_width_ms > s_period_ms[timer]) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Pulse width must be leq period.");
   }
-  status_ok_or_return(prv_check_timer_id(timer));
 
   TIM_OCInitTypeDef oc_init = {
     .TIM_OCMode = TIM_OCMode_PWM1,  // Set on compare match.

--- a/libraries/ms-common/src/stm32f0xx/pwm.c
+++ b/libraries/ms-common/src/stm32f0xx/pwm.c
@@ -25,13 +25,6 @@ static TIM_TypeDef *s_timer_def[NUM_PWM_TIMERS] = {
       [PWM_TIMER_17] = TIM17,  //
 };
 
-static StatusCode prv_check_timer_id(PWMTimer timer) {
-  if (timer >= NUM_PWM_TIMERS) {
-    return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid timer id");
-  }
-  return STATUS_CODE_OK;
-}
-
 static void prv_enable_periph_clock(PWMTimer timer) {
   switch (timer) {
     case PWM_TIMER_1:
@@ -58,10 +51,11 @@ static void prv_enable_periph_clock(PWMTimer timer) {
 }
 
 StatusCode pwm_init(PWMTimer timer, uint16_t period_ms) {
-  if (period_ms == 0) {
+  if (timer >= NUM_PWM_TIMERS) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid timer id");
+  } else if (period_ms == 0) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Period must be greater than 0");
   }
-  status_ok_or_return(prv_check_timer_id(timer));
 
   prv_enable_periph_clock(timer);
 
@@ -86,13 +80,16 @@ StatusCode pwm_init(PWMTimer timer, uint16_t period_ms) {
 }
 
 uint16_t pwm_get_period(PWMTimer timer) {
-  status_ok_or_return(prv_check_timer_id(timer));
+  if (timer >= NUM_PWM_TIMERS) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid timer id");
+  }
   return s_period_ms[timer];
 }
 
 StatusCode pwm_set_pulse(PWMTimer timer, uint16_t pulse_width_ms) {
-  status_ok_or_return(prv_check_timer_id(timer));
-  if (s_period_ms[timer] == 0) {
+  if (timer >= NUM_PWM_TIMERS) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid timer id");
+  } else if (s_period_ms[timer] == 0) {
     return status_msg(STATUS_CODE_UNINITIALIZED, "Pwm must be initialized.");
   } else if (pulse_width_ms > s_period_ms[timer]) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Pulse width must be leq period.");
@@ -123,10 +120,11 @@ StatusCode pwm_set_pulse(PWMTimer timer, uint16_t pulse_width_ms) {
 }
 
 StatusCode pwm_set_dc(PWMTimer timer, uint16_t dc) {
-  if (dc > 100) {
+  if (timer >= NUM_PWM_TIMERS) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid timer id");
+  } else if (dc > 100) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Duty Cycle must be leq 100%.");
   }
-  status_ok_or_return(prv_check_timer_id(timer));
 
   uint16_t pulse_width = 0;
   if (dc != 0) {

--- a/libraries/ms-common/src/x86/pwm.c
+++ b/libraries/ms-common/src/x86/pwm.c
@@ -2,36 +2,21 @@
 
 #include <stdint.h>
 
+#include "pwm_mcu.h"
 #include "status.h"
 
-static uint16_t s_period_ms = 0;
-
-StatusCode pwm_init(uint16_t period_ms) {
-  if (period_ms == 0) {
-    return status_msg(STATUS_CODE_INVALID_ARGS, "Period must be greater than 0");
-  }
-
-  s_period_ms = period_ms;
-
-  return STATUS_CODE_OK;
+StatusCode pwm_init(PWMTimer timer, uint16_t period_ms) {
+  return status_code(STATUS_CODE_UNIMPLEMENTED);
 }
 
-uint16_t pwm_get_period(void) {
-  return s_period_ms;
+uint16_t pwm_get_period(PWMTimer timer) {
+  return status_code(STATUS_CODE_UNIMPLEMENTED);
 }
 
-StatusCode pwm_set_pulse(uint16_t pulse_width_ms) {
-  if (s_period_ms == 0) {
-    return status_msg(STATUS_CODE_UNINITIALIZED, "Pwm must be initialized.");
-  } else if (pulse_width_ms > s_period_ms) {
-    return status_msg(STATUS_CODE_INVALID_ARGS, "Pulse width must be leq period.");
-  }
-  return STATUS_CODE_OK;
+StatusCode pwm_set_pulse(PWMTimer timer, uint16_t pulse_width_ms) {
+  return status_code(STATUS_CODE_UNIMPLEMENTED);
 }
 
-StatusCode pwm_set_dc(uint16_t dc) {
-  if (dc > 100) {
-    return status_msg(STATUS_CODE_INVALID_ARGS, "Duty Cycle must be leq 100%.");
-  }
-  return STATUS_CODE_OK;
+StatusCode pwm_set_dc(PWMTimer timer, uint16_t dc) {
+  return status_code(STATUS_CODE_UNIMPLEMENTED);
 }

--- a/libraries/ms-common/test/test_pwm.c
+++ b/libraries/ms-common/test/test_pwm.c
@@ -2,16 +2,22 @@
 
 #include <stdint.h>
 
+#include "delay.h"
 #include "gpio.h"
 #include "gpio_it.h"
 #include "interrupt.h"
 #include "interrupt_def.h"
 #include "log.h"
+#include "soft_timer.h"
 #include "test_helpers.h"
 #include "unity.h"
 
+#define PWM_TIMER PWM_TIMER_14
 #define PERIOD_MS 100
-#define WAIT_CYCLES 5
+#define DUTY_CYCLE 50
+#define EXPECTED_EDGES 3
+#define PWM_TEST_ADDR \
+  { GPIO_PORT_A, 7 }
 
 static volatile uint16_t s_counter = 0;
 
@@ -21,6 +27,7 @@ static void prv_pwm_test(const GPIOAddress *address, void *context) {
 
 void setup_test(void) {
   interrupt_init();
+  soft_timer_init();
   gpio_init();
   gpio_it_init();
   s_counter = 0;
@@ -29,39 +36,34 @@ void setup_test(void) {
 void teardown_test(void) {}
 
 void test_pwm_guards(void) {
-  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, pwm_set_pulse(PWM_TIMER_3, 50));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(PWM_TIMER_3, 0));
-  TEST_ASSERT_OK(pwm_init(PWM_TIMER_3, PERIOD_MS));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_dc(PWM_TIMER_3, 101));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_pulse(PWM_TIMER_3, PERIOD_MS + 1));
+  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, pwm_set_pulse(PWM_TIMER, DUTY_CYCLE));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(PWM_TIMER, 0));
+  TEST_ASSERT_OK(pwm_init(PWM_TIMER, PERIOD_MS));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_dc(PWM_TIMER, 101));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_pulse(PWM_TIMER, PERIOD_MS + 1));
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(NUM_PWM_TIMERS, PERIOD_MS));
 }
 
 void test_pwm_output(void) {
-  TEST_ASSERT_OK(pwm_init(PWM_TIMER_3, PERIOD_MS));
-  TEST_ASSERT_EQUAL(PERIOD_MS, pwm_get_period(PWM_TIMER_3));
-  TEST_ASSERT_OK(pwm_set_pulse(PWM_TIMER_3, PERIOD_MS - 1));
-  TEST_ASSERT_OK(pwm_set_dc(PWM_TIMER_3, 50));
+  TEST_ASSERT_OK(pwm_init(PWM_TIMER, PERIOD_MS));
+  TEST_ASSERT_EQUAL(PERIOD_MS, pwm_get_period(PWM_TIMER));
+  TEST_ASSERT_OK(pwm_set_pulse(PWM_TIMER, PERIOD_MS - 1));
+  TEST_ASSERT_OK(pwm_set_dc(PWM_TIMER, DUTY_CYCLE));
 
-  const GPIOAddress addr = {
-    .port = GPIO_PORT_A,  //
-    .pin = 6,             //
-  };
+  const GPIOAddress addr = PWM_TEST_ADDR;
   const GPIOSettings settings = {
     .direction = GPIO_DIR_OUT,
     .state = GPIO_STATE_HIGH,
     .resistor = GPIO_RES_PULLUP,
-    .alt_function = GPIO_ALTFN_1,
+    .alt_function = GPIO_ALTFN_4,
   };
   const InterruptSettings it_settings = {
     .type = INTERRUPT_TYPE_INTERRUPT,       //
     .priority = INTERRUPT_PRIORITY_NORMAL,  //
   };
   TEST_ASSERT_OK(gpio_init_pin(&addr, &settings));
-  TEST_ASSERT_OK(gpio_it_register_interrupt(&addr, &it_settings, INTERRUPT_EDGE_RISING_FALLING,
-                                            prv_pwm_test, NULL));
-  while (s_counter < WAIT_CYCLES) {
-  }
-
-  TEST_ASSERT_TRUE(s_counter >= WAIT_CYCLES);
+  TEST_ASSERT_OK(
+      gpio_it_register_interrupt(&addr, &it_settings, INTERRUPT_EDGE_RISING, prv_pwm_test, NULL));
+  delay_ms((EXPECTED_EDGES + 1) * PERIOD_MS);
+  TEST_ASSERT_TRUE(s_counter >= EXPECTED_EDGES);
 }

--- a/libraries/ms-common/test/test_pwm.c
+++ b/libraries/ms-common/test/test_pwm.c
@@ -3,6 +3,8 @@
 #include "test_helpers.h"
 #include "unity.h"
 
+// TODO(ELEC-263): Consider adding functional or more rigorous testing.
+
 #define PERIOD_MS 100
 
 void setup_test(void) {}
@@ -10,16 +12,17 @@ void setup_test(void) {}
 void teardown_test(void) {}
 
 void test_pwm_guards(void) {
-  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, pwm_set_pulse(50));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(0));
-  TEST_ASSERT_OK(pwm_init(PERIOD_MS));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_dc(101));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_pulse(PERIOD_MS + 1));
+  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, pwm_set_pulse(PWM_TIMER_3, 50));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(PWM_TIMER_3, 0));
+  TEST_ASSERT_OK(pwm_init(PWM_TIMER_3, PERIOD_MS));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_dc(PWM_TIMER_3, 101));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_pulse(PWM_TIMER_3, PERIOD_MS + 1));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(NUM_PWM_TIMERS, PERIOD_MS));
 }
 
 void test_pwm_valid_arg(void) {
-  TEST_ASSERT_OK(pwm_init(PERIOD_MS));
-  TEST_ASSERT_EQUAL(PERIOD_MS, pwm_get_period());
-  TEST_ASSERT_OK(pwm_set_dc(50));
-  TEST_ASSERT_OK(pwm_set_pulse(PERIOD_MS - 1));
+  TEST_ASSERT_OK(pwm_init(PWM_TIMER_3, PERIOD_MS));
+  TEST_ASSERT_EQUAL(PERIOD_MS, pwm_get_period(PWM_TIMER_3));
+  TEST_ASSERT_OK(pwm_set_dc(PWM_TIMER_3, 50));
+  TEST_ASSERT_OK(pwm_set_pulse(PWM_TIMER_3, PERIOD_MS - 1));
 }

--- a/libraries/ms-common/test/test_pwm.c
+++ b/libraries/ms-common/test/test_pwm.c
@@ -12,12 +12,13 @@
 #include "test_helpers.h"
 #include "unity.h"
 
-#define PWM_TIMER PWM_TIMER_14
+#define TEST_PWM_TIMER PWM_TIMER_14
+#define TEST_PWM_ADDR \
+  { GPIO_PORT_A, 7 }
+
 #define PERIOD_MS 100
 #define DUTY_CYCLE 50
 #define EXPECTED_EDGES 3
-#define PWM_TEST_ADDR \
-  { GPIO_PORT_A, 7 }
 
 static volatile uint16_t s_counter = 0;
 
@@ -36,21 +37,21 @@ void setup_test(void) {
 void teardown_test(void) {}
 
 void test_pwm_guards(void) {
-  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, pwm_set_pulse(PWM_TIMER, DUTY_CYCLE));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(PWM_TIMER, 0));
-  TEST_ASSERT_OK(pwm_init(PWM_TIMER, PERIOD_MS));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_dc(PWM_TIMER, 101));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_pulse(PWM_TIMER, PERIOD_MS + 1));
+  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, pwm_set_pulse(TEST_PWM_TIMER, DUTY_CYCLE));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(TEST_PWM_TIMER, 0));
+  TEST_ASSERT_OK(pwm_init(TEST_PWM_TIMER, PERIOD_MS));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_dc(TEST_PWM_TIMER, 101));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_pulse(TEST_PWM_TIMER, PERIOD_MS + 1));
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(NUM_PWM_TIMERS, PERIOD_MS));
 }
 
 void test_pwm_output(void) {
-  TEST_ASSERT_OK(pwm_init(PWM_TIMER, PERIOD_MS));
-  TEST_ASSERT_EQUAL(PERIOD_MS, pwm_get_period(PWM_TIMER));
-  TEST_ASSERT_OK(pwm_set_pulse(PWM_TIMER, PERIOD_MS - 1));
-  TEST_ASSERT_OK(pwm_set_dc(PWM_TIMER, DUTY_CYCLE));
+  TEST_ASSERT_OK(pwm_init(TEST_PWM_TIMER, PERIOD_MS));
+  TEST_ASSERT_EQUAL(PERIOD_MS, pwm_get_period(TEST_PWM_TIMER));
+  TEST_ASSERT_OK(pwm_set_pulse(TEST_PWM_TIMER, PERIOD_MS - 1));
+  TEST_ASSERT_OK(pwm_set_dc(TEST_PWM_TIMER, DUTY_CYCLE));
 
-  const GPIOAddress addr = PWM_TEST_ADDR;
+  const GPIOAddress addr = TEST_PWM_ADDR;
   const GPIOSettings settings = {
     .direction = GPIO_DIR_OUT,
     .state = GPIO_STATE_HIGH,

--- a/libraries/ms-common/test/test_pwm.c
+++ b/libraries/ms-common/test/test_pwm.c
@@ -15,10 +15,11 @@
 #define TEST_PWM_TIMER PWM_TIMER_14
 #define TEST_PWM_ADDR \
   { GPIO_PORT_A, 7 }
+#define TEST_PWM_ALTFN GPIO_ALTFN_4
 
-#define PERIOD_MS 100
-#define DUTY_CYCLE 50
-#define EXPECTED_EDGES 3
+#define TEST_PWM_PERIOD_MS 100
+#define TEST_PWM_DUTY_CYCLE 50
+#define TEST_PWM_EXPECTED_EDGES 3
 
 static volatile uint16_t s_counter = 0;
 
@@ -37,26 +38,27 @@ void setup_test(void) {
 void teardown_test(void) {}
 
 void test_pwm_guards(void) {
-  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, pwm_set_pulse(TEST_PWM_TIMER, DUTY_CYCLE));
+  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, pwm_set_pulse(TEST_PWM_TIMER, TEST_PWM_DUTY_CYCLE));
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(TEST_PWM_TIMER, 0));
-  TEST_ASSERT_OK(pwm_init(TEST_PWM_TIMER, PERIOD_MS));
+  TEST_ASSERT_OK(pwm_init(TEST_PWM_TIMER, TEST_PWM_PERIOD_MS));
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_dc(TEST_PWM_TIMER, 101));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_set_pulse(TEST_PWM_TIMER, PERIOD_MS + 1));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(NUM_PWM_TIMERS, PERIOD_MS));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS,
+                    pwm_set_pulse(TEST_PWM_TIMER, TEST_PWM_PERIOD_MS + 1));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(NUM_PWM_TIMERS, TEST_PWM_PERIOD_MS));
 }
 
 void test_pwm_output(void) {
-  TEST_ASSERT_OK(pwm_init(TEST_PWM_TIMER, PERIOD_MS));
-  TEST_ASSERT_EQUAL(PERIOD_MS, pwm_get_period(TEST_PWM_TIMER));
-  TEST_ASSERT_OK(pwm_set_pulse(TEST_PWM_TIMER, PERIOD_MS - 1));
-  TEST_ASSERT_OK(pwm_set_dc(TEST_PWM_TIMER, DUTY_CYCLE));
+  TEST_ASSERT_OK(pwm_init(TEST_PWM_TIMER, TEST_PWM_PERIOD_MS));
+  TEST_ASSERT_EQUAL(TEST_PWM_PERIOD_MS, pwm_get_period(TEST_PWM_TIMER));
+  TEST_ASSERT_OK(pwm_set_pulse(TEST_PWM_TIMER, TEST_PWM_PERIOD_MS - 1));
+  TEST_ASSERT_OK(pwm_set_dc(TEST_PWM_TIMER, TEST_PWM_DUTY_CYCLE));
 
   const GPIOAddress addr = TEST_PWM_ADDR;
   const GPIOSettings settings = {
     .direction = GPIO_DIR_OUT,
     .state = GPIO_STATE_HIGH,
     .resistor = GPIO_RES_PULLUP,
-    .alt_function = GPIO_ALTFN_4,
+    .alt_function = TEST_PWM_ALTFN,
   };
   const InterruptSettings it_settings = {
     .type = INTERRUPT_TYPE_INTERRUPT,       //
@@ -65,6 +67,6 @@ void test_pwm_output(void) {
   TEST_ASSERT_OK(gpio_init_pin(&addr, &settings));
   TEST_ASSERT_OK(
       gpio_it_register_interrupt(&addr, &it_settings, INTERRUPT_EDGE_RISING, prv_pwm_test, NULL));
-  delay_ms((EXPECTED_EDGES + 1) * PERIOD_MS);
-  TEST_ASSERT_TRUE(s_counter >= EXPECTED_EDGES);
+  delay_ms((TEST_PWM_EXPECTED_EDGES + 1) * TEST_PWM_PERIOD_MS);
+  TEST_ASSERT_TRUE(s_counter >= TEST_PWM_EXPECTED_EDGES);
 }

--- a/libraries/ms-common/test/test_pwm.c
+++ b/libraries/ms-common/test/test_pwm.c
@@ -1,13 +1,30 @@
 #include "pwm.h"
 
+#include <stdint.h>
+
+#include "gpio.h"
+#include "gpio_it.h"
+#include "interrupt.h"
+#include "interrupt_def.h"
+#include "log.h"
 #include "test_helpers.h"
 #include "unity.h"
 
-// TODO(ELEC-263): Consider adding functional or more rigorous testing.
-
 #define PERIOD_MS 100
+#define WAIT_CYCLES 5
 
-void setup_test(void) {}
+static volatile uint16_t s_counter = 0;
+
+static void prv_pwm_test(const GPIOAddress *address, void *context) {
+  s_counter++;
+}
+
+void setup_test(void) {
+  interrupt_init();
+  gpio_init();
+  gpio_it_init();
+  s_counter = 0;
+}
 
 void teardown_test(void) {}
 
@@ -20,9 +37,31 @@ void test_pwm_guards(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, pwm_init(NUM_PWM_TIMERS, PERIOD_MS));
 }
 
-void test_pwm_valid_arg(void) {
+void test_pwm_output(void) {
   TEST_ASSERT_OK(pwm_init(PWM_TIMER_3, PERIOD_MS));
   TEST_ASSERT_EQUAL(PERIOD_MS, pwm_get_period(PWM_TIMER_3));
-  TEST_ASSERT_OK(pwm_set_dc(PWM_TIMER_3, 50));
   TEST_ASSERT_OK(pwm_set_pulse(PWM_TIMER_3, PERIOD_MS - 1));
+  TEST_ASSERT_OK(pwm_set_dc(PWM_TIMER_3, 50));
+
+  const GPIOAddress addr = {
+    .port = GPIO_PORT_A,  //
+    .pin = 6,             //
+  };
+  const GPIOSettings settings = {
+    .direction = GPIO_DIR_OUT,
+    .state = GPIO_STATE_HIGH,
+    .resistor = GPIO_RES_PULLUP,
+    .alt_function = GPIO_ALTFN_1,
+  };
+  const InterruptSettings it_settings = {
+    .type = INTERRUPT_TYPE_INTERRUPT,       //
+    .priority = INTERRUPT_PRIORITY_NORMAL,  //
+  };
+  TEST_ASSERT_OK(gpio_init_pin(&addr, &settings));
+  TEST_ASSERT_OK(gpio_it_register_interrupt(&addr, &it_settings, INTERRUPT_EDGE_RISING_FALLING,
+                                            prv_pwm_test, NULL));
+  while (s_counter < WAIT_CYCLES) {
+  }
+
+  TEST_ASSERT_TRUE(s_counter >= WAIT_CYCLES);
 }


### PR DESCRIPTION
This is a relatively simple PR to remove the restriction that `TIM3` is the only timer that can be used on the stm32f0xx architecture for PWM output. ~~I plan to manually perform functional testing for all 6 timers supporting PWM output this afternoon I just wanted to put this up for PR ahead of time.~~ (DONE). Currently, nothing depends on PWM so it would be nice to get this API change in before anything starts relying on it. 