### PR TITLE
ELEC-266: TCP server for x86

### DIFF
--- a/libraries/x86/inc/x86_cmd.h
+++ b/libraries/x86/inc/x86_cmd.h
@@ -1,0 +1,9 @@
+#pragma once
+#include <stddef.h>
+
+typedef void (*X86CmdHandler)(const char *cmd_str, void *context);
+
+void x86_cmd_init(void);
+
+// Note that the handler will be called from another thread - code should be threadsafe
+void x86_cmd_register_handler(const char *cmd, X86CmdHandler handler, void *context);

--- a/libraries/x86/inc/x86_tcp.h
+++ b/libraries/x86/inc/x86_tcp.h
@@ -1,0 +1,5 @@
+#pragma once
+
+typedef void (*X86TcpParser)(const char *str);
+
+void x86_tcp_init(X86TcpParser parser);

--- a/libraries/x86/rules.mk
+++ b/libraries/x86/rules.mk
@@ -9,3 +9,8 @@ $(T)_DEPS := libcore
 
 # Specifies library specific build flags
 $(T)_CFLAGS += -ffreestanding
+
+ifeq (x86,$(PLATFORM))
+# Force the include of x86_cmd to allow its constructor to be linked
+$(GDB_TARGET): $($(T)_OBJ_ROOT)/x86_cmd.o
+endif

--- a/libraries/x86/src/x86_cmd.c
+++ b/libraries/x86/src/x86_cmd.c
@@ -17,7 +17,8 @@ static X86CmdHandlerData s_handlers[X86_CMD_MAX_HANDLERS] = { 0 };
 static size_t s_num_handlers = 0;
 
 static void prv_parser(const char *str) {
-  printf("%s\n", str);
+  printf("Received command: %s\n", str);
+  // only need to copy the first word - don't care about the rest
   char str_buf[X86_CMD_MAX_LEN] = { 0 };
   strncpy(str_buf, str, X86_CMD_MAX_LEN);
   char *cmd_word = strtok(str_buf, " ");
@@ -43,10 +44,11 @@ void __attribute__((constructor)) x86_cmd_init(void) {
 }
 
 void x86_cmd_register_handler(const char *cmd, X86CmdHandler handler, void *context) {
-  // TODO error checking
-  s_handlers[s_num_handlers++] = (X86CmdHandlerData) {
-    .handler = handler,
-    .context = context,
-    .cmd = cmd
-  };
+  if (s_num_handlers < X86_CMD_MAX_HANDLERS) {
+    s_handlers[s_num_handlers++] = (X86CmdHandlerData) {
+      .handler = handler,
+      .context = context,
+      .cmd = cmd
+    };
+  }
 }

--- a/libraries/x86/src/x86_cmd.c
+++ b/libraries/x86/src/x86_cmd.c
@@ -1,7 +1,113 @@
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
 #include <pthread.h>
-#include <sys/socket.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
 
-void  __attribute__((constructor)) x86_cmd_init(void) {
-  printf("hello\n");
+#define X86_CMD_MAX_CLIENTS 10
+#define X86_CMD_MAX_PENDING_CONNS 3
+#define X86_CMD_PORT 4000
+#define X86_CMD_BUF_LEN 1024
+
+void *prv_serve_thread(void *unused) {
+  bool opt = true;
+  int server_fd = 0;
+  int addrlen = 0;
+  int max_fd = 0;
+  int client_fds[X86_CMD_MAX_CLIENTS] = { 0 };
+  struct sockaddr_in addr = { 0 };
+  char buf[X86_CMD_BUF_LEN + 1] = { 0 };  // Extra for null terminator
+
+  fd_set readfds = { 0 };
+
+  server_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (server_fd == 0) {
+    printf("Failed to create socket!\n");
+    return NULL;
+  }
+
+  setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, (void *)&opt, sizeof(opt));
+
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(X86_CMD_PORT);
+
+  if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    printf("Failed to bind socket!\n");
+    return NULL;
+  }
+
+  if (listen(server_fd, X86_CMD_MAX_PENDING_CONNS) < 0) {
+    printf("Failed to specify maximum pending connections\n");
+    return NULL;
+  }
+
+  addrlen = sizeof(addr);
+
+  while (true) {
+    FD_ZERO(&readfds);
+    FD_SET(server_fd, &readfds);
+    max_fd = server_fd;
+
+    for (int i = 0; i < X86_CMD_MAX_CLIENTS; i++) {
+      if (client_fds[i] > 0) {
+        FD_SET(client_fds[i], &readfds);
+      }
+
+      if (client_fds[i] > max_fd) {
+        max_fd = client_fds[i];
+      }
+    }
+
+    // Infinite timeout
+    select(max_fd + 1, &readfds, NULL, NULL, NULL);
+
+    if (FD_ISSET(server_fd, &readfds)) {
+      // Server read - new client
+      int new_socket = accept(server_fd, (struct sockaddr *)&addr, (socklen_t *)&addrlen);
+      if (new_socket < 0) {
+        printf("Failed to accept new client!\n");
+      }
+      printf("New client %d from %s:%d connected!\n", new_socket, inet_ntoa(addr.sin_addr),
+             ntohs(addr.sin_port));
+
+      for (int i = 0; i < X86_CMD_MAX_CLIENTS; i++) {
+        if (client_fds[i] == 0) {
+          client_fds[i] = new_socket;
+        }
+      }
+    }
+
+    for (int i = 0; i < X86_CMD_MAX_CLIENTS; i++) {
+      int client_fd = client_fds[i];
+      if (FD_ISSET(client_fd, &readfds)) {
+        ssize_t read_len = read(client_fd, buf, X86_CMD_BUF_LEN);
+        if (read_len == 0) {
+          // Disconnected
+          printf("Client disconnected\n");
+          close(client_fd);
+          client_fds[i] = 0;
+        } else if (read_len > 0) {
+          // Replace newline with null terminator
+          buf[read_len - 1] = '\0';
+          if (buf[read_len - 2] == 13) {
+            buf[read_len - 2] = '\0';
+          }
+          printf("RX %s\n", buf);
+        }
+      }
+    }
+  }
+
+  return NULL;
+}
+
+void __attribute__((constructor)) x86_cmd_init(void) {
+  pthread_t thread_id;
+  pthread_create(&thread_id, NULL, prv_serve_thread, NULL);
 }

--- a/libraries/x86/src/x86_cmd.c
+++ b/libraries/x86/src/x86_cmd.c
@@ -1,113 +1,52 @@
-#include <arpa/inet.h>
-#include <errno.h>
-#include <netdb.h>
-#include <netinet/in.h>
-#include <pthread.h>
-#include <stdbool.h>
+#include "x86_cmd.h"
 #include <stdio.h>
 #include <string.h>
-#include <sys/socket.h>
-#include <unistd.h>
+#include <stdlib.h>
+#include "x86_tcp.h"
 
-#define X86_CMD_MAX_CLIENTS 10
-#define X86_CMD_MAX_PENDING_CONNS 3
-#define X86_CMD_PORT 4000
-#define X86_CMD_BUF_LEN 1024
+#define X86_CMD_MAX_HANDLERS 16
+#define X86_CMD_MAX_LEN 16
 
-void *prv_serve_thread(void *unused) {
-  bool opt = true;
-  int server_fd = 0;
-  int addrlen = 0;
-  int max_fd = 0;
-  int client_fds[X86_CMD_MAX_CLIENTS] = { 0 };
-  struct sockaddr_in addr = { 0 };
-  char buf[X86_CMD_BUF_LEN + 1] = { 0 };  // Extra for null terminator
+typedef struct X86CmdHandlerData {
+  X86CmdHandler handler;
+  void *context;
+  const char *cmd;
+} X86CmdHandlerData;
 
-  fd_set readfds = { 0 };
+static X86CmdHandlerData s_handlers[X86_CMD_MAX_HANDLERS] = { 0 };
+static size_t s_num_handlers = 0;
 
-  server_fd = socket(AF_INET, SOCK_STREAM, 0);
-  if (server_fd == 0) {
-    printf("Failed to create socket!\n");
-    return NULL;
-  }
+static void prv_parser(const char *str) {
+  printf("%s\n", str);
+  char str_buf[X86_CMD_MAX_LEN] = { 0 };
+  strncpy(str_buf, str, X86_CMD_MAX_LEN);
+  char *cmd_word = strtok(str_buf, " ");
 
-  setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, (void *)&opt, sizeof(opt));
-
-  addr.sin_family = AF_INET;
-  addr.sin_addr.s_addr = INADDR_ANY;
-  addr.sin_port = htons(X86_CMD_PORT);
-
-  if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
-    printf("Failed to bind socket!\n");
-    return NULL;
-  }
-
-  if (listen(server_fd, X86_CMD_MAX_PENDING_CONNS) < 0) {
-    printf("Failed to specify maximum pending connections\n");
-    return NULL;
-  }
-
-  addrlen = sizeof(addr);
-
-  while (true) {
-    FD_ZERO(&readfds);
-    FD_SET(server_fd, &readfds);
-    max_fd = server_fd;
-
-    for (int i = 0; i < X86_CMD_MAX_CLIENTS; i++) {
-      if (client_fds[i] > 0) {
-        FD_SET(client_fds[i], &readfds);
-      }
-
-      if (client_fds[i] > max_fd) {
-        max_fd = client_fds[i];
-      }
-    }
-
-    // Infinite timeout
-    select(max_fd + 1, &readfds, NULL, NULL, NULL);
-
-    if (FD_ISSET(server_fd, &readfds)) {
-      // Server read - new client
-      int new_socket = accept(server_fd, (struct sockaddr *)&addr, (socklen_t *)&addrlen);
-      if (new_socket < 0) {
-        printf("Failed to accept new client!\n");
-      }
-      printf("New client %d from %s:%d connected!\n", new_socket, inet_ntoa(addr.sin_addr),
-             ntohs(addr.sin_port));
-
-      for (int i = 0; i < X86_CMD_MAX_CLIENTS; i++) {
-        if (client_fds[i] == 0) {
-          client_fds[i] = new_socket;
-        }
-      }
-    }
-
-    for (int i = 0; i < X86_CMD_MAX_CLIENTS; i++) {
-      int client_fd = client_fds[i];
-      if (FD_ISSET(client_fd, &readfds)) {
-        ssize_t read_len = read(client_fd, buf, X86_CMD_BUF_LEN);
-        if (read_len == 0) {
-          // Disconnected
-          printf("Client disconnected\n");
-          close(client_fd);
-          client_fds[i] = 0;
-        } else if (read_len > 0) {
-          // Replace newline with null terminator
-          buf[read_len - 1] = '\0';
-          if (buf[read_len - 2] == 13) {
-            buf[read_len - 2] = '\0';
-          }
-          printf("RX %s\n", buf);
-        }
-      }
+  for (size_t i = 0; i < s_num_handlers; i++) {
+    if (strcmp(s_handlers[i].cmd, cmd_word) == 0) {
+      s_handlers[i].handler(str, s_handlers[i].context);
+      break;
     }
   }
+}
 
-  return NULL;
+static void prv_quit(const char *cmd_str, void *context) {
+  printf("Command received - Quitting\n");
+  exit(EXIT_SUCCESS);
 }
 
 void __attribute__((constructor)) x86_cmd_init(void) {
-  pthread_t thread_id;
-  pthread_create(&thread_id, NULL, prv_serve_thread, NULL);
+  x86_tcp_init(prv_parser);
+
+  // Allow force quit on x86 - good for integration testing
+  x86_cmd_register_handler("quit", prv_quit, NULL);
+}
+
+void x86_cmd_register_handler(const char *cmd, X86CmdHandler handler, void *context) {
+  // TODO error checking
+  s_handlers[s_num_handlers++] = (X86CmdHandlerData) {
+    .handler = handler,
+    .context = context,
+    .cmd = cmd
+  };
 }

--- a/libraries/x86/src/x86_cmd.c
+++ b/libraries/x86/src/x86_cmd.c
@@ -1,7 +1,7 @@
 #include "x86_cmd.h"
 #include <stdio.h>
-#include <string.h>
 #include <stdlib.h>
+#include <string.h>
 #include "x86_tcp.h"
 
 #define X86_CMD_MAX_HANDLERS 16
@@ -18,10 +18,13 @@ static size_t s_num_handlers = 0;
 
 static void prv_parser(const char *str) {
   printf("Received command: %s\n", str);
-  // only need to copy the first word - don't care about the rest
+
+  // Only need to copy the first word - don't care about the rest
   char str_buf[X86_CMD_MAX_LEN] = { 0 };
   strncpy(str_buf, str, X86_CMD_MAX_LEN);
-  char *cmd_word = strtok(str_buf, " ");
+
+  char *save_ptr = NULL;
+  char *cmd_word = strtok_r(str_buf, " ", &save_ptr);
 
   for (size_t i = 0; i < s_num_handlers; i++) {
     if (strcmp(s_handlers[i].cmd, cmd_word) == 0) {
@@ -45,10 +48,10 @@ void __attribute__((constructor)) x86_cmd_init(void) {
 
 void x86_cmd_register_handler(const char *cmd, X86CmdHandler handler, void *context) {
   if (s_num_handlers < X86_CMD_MAX_HANDLERS) {
-    s_handlers[s_num_handlers++] = (X86CmdHandlerData) {
-      .handler = handler,
-      .context = context,
-      .cmd = cmd
+    s_handlers[s_num_handlers++] = (X86CmdHandlerData){
+      .handler = handler,  //
+      .context = context,  //
+      .cmd = cmd,          //
     };
   }
 }

--- a/libraries/x86/src/x86_cmd.c
+++ b/libraries/x86/src/x86_cmd.c
@@ -1,0 +1,7 @@
+#include <pthread.h>
+#include <sys/socket.h>
+#include <stdio.h>
+
+void  __attribute__((constructor)) x86_cmd_init(void) {
+  printf("hello\n");
+}

--- a/libraries/x86/src/x86_tcp.c
+++ b/libraries/x86/src/x86_tcp.c
@@ -25,12 +25,10 @@ static int prv_setup_socket(void) {
   bool opt = true;
   setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, (void *)&opt, sizeof(opt));
 
-  struct sockaddr_in addr = {
-    .sin_family = AF_INET,
-    .sin_addr.s_addr = INADDR_ANY,
-    .sin_port = htons(X86_TCP_PORT),
-    .sin_zero = { 0 }
-  };
+  struct sockaddr_in addr = {.sin_family = AF_INET,
+                             .sin_addr.s_addr = INADDR_ANY,
+                             .sin_port = htons(X86_TCP_PORT),
+                             .sin_zero = { 0 } };
   if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
     printf("Failed to bind socket\n");
     return -1;
@@ -48,8 +46,7 @@ static void *prv_serve_thread(void *arg) {
   X86TcpParser parser = arg;
   int server_fd = prv_setup_socket();
   int client_fds[X86_TCP_MAX_CLIENTS] = { 0 };
-  char buf[X86_TCP_BUF_LEN + 1] = { 0 }; // Extra for null terminator
-
+  char buf[X86_TCP_BUF_LEN + 1] = { 0 };  // Extra for null terminator
 
   while (true) {
     fd_set readfds = { 0 };

--- a/libraries/x86/src/x86_tcp.c
+++ b/libraries/x86/src/x86_tcp.c
@@ -1,0 +1,123 @@
+#include "x86_tcp.h"
+#include <arpa/inet.h>
+#include <errno.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <pthread.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#define X86_TCP_PORT 4000
+#define X86_TCP_BUF_LEN 1024
+#define X86_TCP_MAX_CLIENTS 10
+#define X86_TCP_MAX_PENDING_CONNECTIONS 3
+
+static int prv_setup_socket(void) {
+  int server_fd = socket(AF_INET, SOCK_STREAM, 0);
+  if (server_fd == 0) {
+    printf("Failed to create socket\n");
+    return -1;
+  }
+
+  bool opt = true;
+  setsockopt(server_fd, SOL_SOCKET, SO_REUSEADDR, (void *)&opt, sizeof(opt));
+
+  struct sockaddr_in addr = {
+    .sin_family = AF_INET,
+    .sin_addr.s_addr = INADDR_ANY,
+    .sin_port = htons(X86_TCP_PORT),
+    .sin_zero = { 0 }
+  };
+  if (bind(server_fd, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+    printf("Failed to bind socket\n");
+    return -1;
+  }
+
+  if (listen(server_fd, X86_TCP_MAX_PENDING_CONNECTIONS) < 0) {
+    printf("Failed to specify maximum pending connections\n");
+    return -1;
+  }
+
+  return server_fd;
+}
+
+static void *prv_serve_thread(void *arg) {
+  X86TcpParser parser = arg;
+  int server_fd = prv_setup_socket();
+  int client_fds[X86_TCP_MAX_CLIENTS] = { 0 };
+  char buf[X86_TCP_BUF_LEN + 1] = { 0 }; // Extra for null terminator
+
+
+  while (true) {
+    fd_set readfds = { 0 };
+    FD_ZERO(&readfds);
+    FD_SET(server_fd, &readfds);
+    int max_fd = server_fd;
+
+    for (size_t i = 0; i < X86_TCP_MAX_CLIENTS; i++) {
+      if (client_fds[i] > 0) {
+        FD_SET(client_fds[i], &readfds);
+      }
+
+      if (client_fds[i] > max_fd) {
+        max_fd = client_fds[i];
+      }
+    }
+
+    // Infinite timeout
+    select(max_fd + 1, &readfds, NULL, NULL, NULL);
+
+    // Server read - new client
+    if (FD_ISSET(server_fd, &readfds)) {
+      struct sockaddr_in addr = { 0 };
+      socklen_t addrlen = sizeof(addr);
+      int new_socket = accept(server_fd, (struct sockaddr *)&addr, &addrlen);
+      if (new_socket < 0) {
+        printf("Failed to accept new client!\n");
+      }
+      printf("New client %d from %s:%d connected!\n", new_socket, inet_ntoa(addr.sin_addr),
+             ntohs(addr.sin_port));
+
+      for (size_t i = 0; i < X86_TCP_MAX_CLIENTS; i++) {
+        if (client_fds[i] == 0) {
+          client_fds[i] = new_socket;
+          break;
+        }
+      }
+    }
+
+    // Handle client reads - incoming data or disconnect
+    for (size_t i = 0; i < X86_TCP_MAX_CLIENTS; i++) {
+      int client_fd = client_fds[i];
+      if (FD_ISSET(client_fd, &readfds)) {
+        ssize_t read_len = read(client_fd, buf, X86_TCP_BUF_LEN);
+        if (read_len == 0) {
+          // Disconnected
+          printf("Client disconnected\n");
+          close(client_fd);
+          client_fds[i] = 0;
+        } else if (read_len > 0) {
+          // Replace newline with null terminator
+          buf[read_len - 1] = '\0';
+          if (buf[read_len - 2] == 13) {
+            buf[read_len - 2] = '\0';
+          }
+
+          if (parser != NULL) {
+            parser(buf);
+          }
+        }
+      }
+    }
+  }
+
+  return NULL;
+}
+
+void x86_tcp_init(X86TcpParser parser) {
+  pthread_t thread_id;
+  pthread_create(&thread_id, NULL, prv_serve_thread, parser);
+}

--- a/make/build.mk
+++ b/make/build.mk
@@ -38,7 +38,7 @@ $(T)_OBJ := $($(T)_OBJ:$($(T)_SRC_ROOT)/%.s=$($(T)_OBJ_ROOT)/%.o)
 # Static library link target
 $(STATIC_LIB_DIR)/lib$(T).a: $($(T)_OBJ) $(call dep_to_lib,$($(T)_DEPS)) | $(STATIC_LIB_DIR)
 	@echo "Linking $@"
-	@$(AR) -r $@ $^
+	@$(AR) -rcs $@ $^
 
 # Application target
 $(BIN_DIR)/$(T)$(PLATFORM_EXT): $($(T)_OBJ) $(call dep_to_lib,$($(T)_DEPS)) | $(T) $(BIN_DIR)

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -39,7 +39,7 @@ endif
 
 CFLAGS := $(CSFLAGS) -Wall -Wextra -Werror -std=gnu11 -Wno-discarded-qualifiers \
           -Wno-unused-variable -Wno-unused-parameter -Wsign-conversion -Wpointer-arith \
-          -ffunction-sections -fdata-sections \
+          -ffunction-sections -fdata-sections -pthread \
           $(ARCH_CFLAGS) $(addprefix -D,$(CDEFINES))
 
 # Linker flags

--- a/projects/queue/src/main.c
+++ b/projects/queue/src/main.c
@@ -16,5 +16,7 @@ int main(void) {
     printf("id: %d data: %d\n", e.id, e.data);
   }
 
+  while (1) {}
+
   return 0;
 }

--- a/projects/queue/src/main.c
+++ b/projects/queue/src/main.c
@@ -16,7 +16,5 @@ int main(void) {
     printf("id: %d data: %d\n", e.id, e.data);
   }
 
-  while (1) {}
-
   return 0;
 }

--- a/projects/queue/src/main.c
+++ b/projects/queue/src/main.c
@@ -12,7 +12,7 @@ int main(void) {
   event_raise(60, 3);
 
   Event e;
-  while (event_process(&e)) {
+  while (event_process(&e) == STATUS_CODE_OK) {
     printf("id: %d data: %d\n", e.id, e.data);
   }
 


### PR DESCRIPTION
This is more of a preliminary investigation into a potential solution than a fleshed-out design.
This PR adds a TCP server running in another thread that listens for registered commands. By default, `quit` will exit the program. The idea is that modules can register additional command handlers and we can write scripts to run x86 integration testing for application logic. Arguments can be parsed within handlers.

I'm mostly interested in thoughts on the concept and whether it makes sense/is useful.

For testing, `telnet localhost 4000` or `netcat localhost 4000` will work.
TODO: Add documentation, potentially move to StatusCodes.