### PR TITLE
ELEC-278: Fix socketcan reinit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -182,6 +182,6 @@ socketcan:
 	@sudo modprobe can
 	@sudo modprobe can_raw
 	@sudo modprobe vcan
-	@sudo ip link add dev vcan0 type vcan
-	@sudo ip link set up vcan0
+	@sudo ip link add dev vcan0 type vcan || true
+	@sudo ip link set up vcan0 || true
 	@ip link show vcan0


### PR DESCRIPTION
Adds `|| true` to `socketcan` so calling it twice won't fault.