### PR TITLE
ELEC-276: CAN Pack and Unpack implementations

### DIFF
--- a/libraries/ms-common/inc/can_pack_impl.h
+++ b/libraries/ms-common/inc/can_pack_impl.h
@@ -1,26 +1,32 @@
 #pragma once
 
+#include <stddef.h>
 #include <stdint.h>
 
 #include "can_msg.h"
+#include "status.h"
 
+#define CAN_PACK_IMPL_MAX_DLC 8
 #define CAN_PACK_IMPL_EMPTY 0
+#define CAN_PACK_IMPL_NO_BYTES 0
 
 // Packs eight u8s into a CAN Msg
-void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, uint8_t f1, uint8_t f2,
-                      uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6, uint8_t f7, uint8_t f8);
+StatusCode can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
+                            uint8_t f1, uint8_t f2, uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6,
+                            uint8_t f7, uint8_t f8);
 
 // Packs four u16s into a CAN Msg
-void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, uint16_t f1,
-                       uint16_t f2, uint16_t f3, uint16_t f4);
+StatusCode can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
+                             uint16_t f1, uint16_t f2, uint16_t f3, uint16_t f4);
 
 // Packs a pair of u32 into a CAN Msg
-void can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, uint32_t f1,
-                       uint32_t f2);
+StatusCode can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
+                             uint32_t f1, uint32_t f2);
 
 // Packs a u64 into a CAN Msg
-void can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, uint64_t f1);
+StatusCode can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
+                             uint64_t f1);
 
 // Packs an empty CAN Msg
 #define can_pack_impl_empty(msg_ptr, source_id, id) \
-  can_pack_impl_u64((msg_ptr), (source_id), (id), CAN_PACK_IMPL_EMPTY)
+  can_pack_impl_u64((msg_ptr), (source_id), (id), CAN_PACK_IMPL_NO_BYTES, CAN_PACK_IMPL_EMPTY)

--- a/libraries/ms-common/inc/can_pack_impl.h
+++ b/libraries/ms-common/inc/can_pack_impl.h
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <stdint.h>
+
+#include "can_msg.h"
+
+#define CAN_PACK_IMPL_EMPTY 0
+
+// Packs eight u8s into a CAN Msg
+void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
+                      uint8_t f1, uint8_t f2, uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6,
+                      uint8_t f7, uint8_t f8);
+
+// Packs four u16s into a CAN Msg
+void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
+                       uint16_t f1, uint16_t f2, uint16_t f3, uint16_t f4);
+
+// Packs a pair of u32 into a CAN Msg
+void can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
+                       uint32_t f1, uint32_t f2);
+
+// Packs a u64 into a CAN Msg
+void can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
+                       uint64_t f1);
+
+// Packs an empty CAN Msg
+#define can_pack_impl_empty(msg_ptr, source_id, id, type) \
+  can_pack_impl_u64((msg_ptr), (source_id), (id), (type), CAN_PACK_IMPL_EMPTY)

--- a/libraries/ms-common/inc/can_pack_impl.h
+++ b/libraries/ms-common/inc/can_pack_impl.h
@@ -7,22 +7,20 @@
 #define CAN_PACK_IMPL_EMPTY 0
 
 // Packs eight u8s into a CAN Msg
-void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
-                      uint8_t f1, uint8_t f2, uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6,
-                      uint8_t f7, uint8_t f8);
+void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, uint8_t f1, uint8_t f2,
+                      uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6, uint8_t f7, uint8_t f8);
 
 // Packs four u16s into a CAN Msg
-void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
-                       uint16_t f1, uint16_t f2, uint16_t f3, uint16_t f4);
+void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, uint16_t f1,
+                       uint16_t f2, uint16_t f3, uint16_t f4);
 
 // Packs a pair of u32 into a CAN Msg
-void can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
-                       uint32_t f1, uint32_t f2);
+void can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, uint32_t f1,
+                       uint32_t f2);
 
 // Packs a u64 into a CAN Msg
-void can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
-                       uint64_t f1);
+void can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, uint64_t f1);
 
 // Packs an empty CAN Msg
-#define can_pack_impl_empty(msg_ptr, source_id, id, type) \
-  can_pack_impl_u64((msg_ptr), (source_id), (id), (type), CAN_PACK_IMPL_EMPTY)
+#define can_pack_impl_empty(msg_ptr, source_id, id) \
+  can_pack_impl_u64((msg_ptr), (source_id), (id), CAN_PACK_IMPL_EMPTY)

--- a/libraries/ms-common/inc/can_unpack_impl.h
+++ b/libraries/ms-common/inc/can_unpack_impl.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "can_msg.h"
+
+#define CAN_UNPACK_IMPL_EMPTY NULL
+
+// Unpacks eight u8s from a CAN Msg
+void can_unpack_impl_u8(const CANMessage *msg, uint8_t *f1, uint8_t *f2, uint8_t *f3, uint8_t *f4,
+                        uint8_t *f5, uint8_t *f6, uint8_t *f7, uint8_t *f8);
+
+// Unpacks four u16s from a CAN Msg
+void can_unpack_impl_u16(const CANMessage *msg, uint16_t *f1, uint16_t *f2, uint16_t *f3,
+                         uint16_t *f4);
+
+// Unpacks a pair of u32 from a CAN Msg
+void can_unpack_impl_u32(const CANMessage *msg, uint32_t *f1, uint32_t *f2);
+
+// Unpacks a u64 from a CAN Msg
+void can_unpack_impl_u64(const CANMessage *msg, uint64_t *f1);
+
+// This doesn't do anything since there is no data to unpack. The purpose of this is so that codegen
+// doesn't require a special edge case and so every message has an unpack macro.
+#define can_unpack_impl_empty(msg_ptr)

--- a/libraries/ms-common/inc/can_unpack_impl.h
+++ b/libraries/ms-common/inc/can_unpack_impl.h
@@ -4,22 +4,25 @@
 #include <stdint.h>
 
 #include "can_msg.h"
+#include "status.h"
 
 #define CAN_UNPACK_IMPL_EMPTY NULL
 
 // Unpacks eight u8s from a CAN Msg
-void can_unpack_impl_u8(const CANMessage *msg, uint8_t *f1, uint8_t *f2, uint8_t *f3, uint8_t *f4,
-                        uint8_t *f5, uint8_t *f6, uint8_t *f7, uint8_t *f8);
+StatusCode can_unpack_impl_u8(const CANMessage *msg, size_t expected_dlc, uint8_t *f1, uint8_t *f2,
+                              uint8_t *f3, uint8_t *f4, uint8_t *f5, uint8_t *f6, uint8_t *f7,
+                              uint8_t *f8);
 
 // Unpacks four u16s from a CAN Msg
-void can_unpack_impl_u16(const CANMessage *msg, uint16_t *f1, uint16_t *f2, uint16_t *f3,
-                         uint16_t *f4);
+StatusCode can_unpack_impl_u16(const CANMessage *msg, size_t expected_dlc, uint16_t *f1,
+                               uint16_t *f2, uint16_t *f3, uint16_t *f4);
 
 // Unpacks a pair of u32 from a CAN Msg
-void can_unpack_impl_u32(const CANMessage *msg, uint32_t *f1, uint32_t *f2);
+StatusCode can_unpack_impl_u32(const CANMessage *msg, size_t expected_dlc, uint32_t *f1,
+                               uint32_t *f2);
 
 // Unpacks a u64 from a CAN Msg
-void can_unpack_impl_u64(const CANMessage *msg, uint64_t *f1);
+StatusCode can_unpack_impl_u64(const CANMessage *msg, size_t expected_dlc, uint64_t *f1);
 
 // This doesn't do anything since there is no data to unpack. The purpose of this is so that codegen
 // doesn't require a special edge case and so every message has an unpack macro.

--- a/libraries/ms-common/src/can_pack_impl.c
+++ b/libraries/ms-common/src/can_pack_impl.c
@@ -3,6 +3,7 @@
 #include <stdint.h>
 
 #include "can_msg.h"
+#include "status.h"
 
 StatusCode can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
                             uint8_t f1, uint8_t f2, uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6,

--- a/libraries/ms-common/src/can_pack_impl.c
+++ b/libraries/ms-common/src/can_pack_impl.c
@@ -1,18 +1,18 @@
 #include "can_pack_impl.h"
 
+#include <limits.h>
 #include <stdint.h>
 
 #include "can_msg.h"
 
 // Calculate the number of used bytes if the trailing bytes are 0 or unused then there is no point
 // wasting bus time transmitting them.
-#define CAN_PACK_CALC_DLC(data) 8 - (size_t)__builtin_ffsll((int64_t)(data)) / 8
+#define CAN_PACK_CALC_DLC(data) CHAR_BIT - (size_t)__builtin_ffsll((int64_t)(data)) / CHAR_BIT
 
-void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
-                      uint8_t f1, uint8_t f2, uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6,
-                      uint8_t f7, uint8_t f8) {
+void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, uint8_t f1, uint8_t f2,
+                      uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6, uint8_t f7, uint8_t f8) {
   *msg = (CANMessage){
-    .type = type,                                   //
+    .type = CAN_MSG_TYPE_DATA,                      //
     .source_id = source_id,                         //
     .msg_id = id,                                   //
     .data_u8 = { f1, f2, f3, f4, f5, f6, f7, f8 },  //
@@ -20,10 +20,10 @@ void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, CANM
   msg->dlc = CAN_PACK_CALC_DLC(msg->data);
 }
 
-void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
-                       uint16_t f1, uint16_t f2, uint16_t f3, uint16_t f4) {
+void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, uint16_t f1,
+                       uint16_t f2, uint16_t f3, uint16_t f4) {
   *msg = (CANMessage){
-    .type = type,                    //
+    .type = CAN_MSG_TYPE_DATA,       //
     .source_id = source_id,          //
     .msg_id = id,                    //
     .data_u16 = { f1, f2, f3, f4 },  //
@@ -31,24 +31,23 @@ void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, CAN
   msg->dlc = CAN_PACK_CALC_DLC(msg->data);
 }
 
-void can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
-                       uint32_t f1, uint32_t f2) {
+void can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, uint32_t f1,
+                       uint32_t f2) {
   *msg = (CANMessage){
-    .type = type,            //
-    .source_id = source_id,  //
-    .msg_id = id,            //
-    .data_u32 = { f1, f2 },  //
+    .type = CAN_MSG_TYPE_DATA,  //
+    .source_id = source_id,     //
+    .msg_id = id,               //
+    .data_u32 = { f1, f2 },     //
   };
   msg->dlc = CAN_PACK_CALC_DLC(msg->data);
 }
 
-void can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
-                       uint64_t f1) {
+void can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, uint64_t f1) {
   *msg = (CANMessage){
-    .type = type,            //
-    .source_id = source_id,  //
-    .msg_id = id,            //
-    .data = f1,              //
+    .type = CAN_MSG_TYPE_DATA,  //
+    .source_id = source_id,     //
+    .msg_id = id,               //
+    .data = f1,                 //
   };
   msg->dlc = CAN_PACK_CALC_DLC(msg->data);
 }

--- a/libraries/ms-common/src/can_pack_impl.c
+++ b/libraries/ms-common/src/can_pack_impl.c
@@ -1,53 +1,66 @@
 #include "can_pack_impl.h"
 
-#include <limits.h>
 #include <stdint.h>
 
 #include "can_msg.h"
 
-// Calculate the number of used bytes if the trailing bytes are 0 or unused then there is no point
-// wasting bus time transmitting them.
-#define CAN_PACK_CALC_DLC(data) CHAR_BIT - (size_t)__builtin_ffsll((int64_t)(data)) / CHAR_BIT
-
-void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, uint8_t f1, uint8_t f2,
-                      uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6, uint8_t f7, uint8_t f8) {
+StatusCode can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
+                            uint8_t f1, uint8_t f2, uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6,
+                            uint8_t f7, uint8_t f8) {
+  if (num_bytes > CAN_PACK_IMPL_MAX_DLC) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "DLC too large");
+  }
   *msg = (CANMessage){
     .type = CAN_MSG_TYPE_DATA,                      //
     .source_id = source_id,                         //
     .msg_id = id,                                   //
     .data_u8 = { f1, f2, f3, f4, f5, f6, f7, f8 },  //
+    .dlc = num_bytes,                               //
   };
-  msg->dlc = CAN_PACK_CALC_DLC(msg->data);
+  return STATUS_CODE_OK;
 }
 
-void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, uint16_t f1,
-                       uint16_t f2, uint16_t f3, uint16_t f4) {
+StatusCode can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
+                             uint16_t f1, uint16_t f2, uint16_t f3, uint16_t f4) {
+  if (num_bytes > CAN_PACK_IMPL_MAX_DLC) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "DLC too large");
+  }
   *msg = (CANMessage){
     .type = CAN_MSG_TYPE_DATA,       //
     .source_id = source_id,          //
     .msg_id = id,                    //
     .data_u16 = { f1, f2, f3, f4 },  //
+    .dlc = num_bytes,                //
   };
-  msg->dlc = CAN_PACK_CALC_DLC(msg->data);
+  return STATUS_CODE_OK;
 }
 
-void can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, uint32_t f1,
-                       uint32_t f2) {
+StatusCode can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
+                             uint32_t f1, uint32_t f2) {
+  if (num_bytes > CAN_PACK_IMPL_MAX_DLC) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "DLC too large");
+  }
   *msg = (CANMessage){
     .type = CAN_MSG_TYPE_DATA,  //
     .source_id = source_id,     //
     .msg_id = id,               //
     .data_u32 = { f1, f2 },     //
+    .dlc = num_bytes,           //
   };
-  msg->dlc = CAN_PACK_CALC_DLC(msg->data);
+  return STATUS_CODE_OK;
 }
 
-void can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, uint64_t f1) {
+StatusCode can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, size_t num_bytes,
+                             uint64_t f1) {
+  if (num_bytes > CAN_PACK_IMPL_MAX_DLC) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "DLC too large");
+  }
   *msg = (CANMessage){
     .type = CAN_MSG_TYPE_DATA,  //
     .source_id = source_id,     //
     .msg_id = id,               //
     .data = f1,                 //
+    .dlc = num_bytes,           //
   };
-  msg->dlc = CAN_PACK_CALC_DLC(msg->data);
+  return STATUS_CODE_OK;
 }

--- a/libraries/ms-common/src/can_pack_impl.c
+++ b/libraries/ms-common/src/can_pack_impl.c
@@ -1,0 +1,54 @@
+#include "can_pack_impl.h"
+
+#include <stdint.h>
+
+#include "can_msg.h"
+
+// Calculate the number of used bytes if the trailing bytes are 0 or unused then there is no point
+// wasting bus time transmitting them.
+#define CAN_PACK_CALC_DLC(data) 8 - (size_t)__builtin_ffsll((int64_t)(data)) / 8
+
+void can_pack_impl_u8(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
+                      uint8_t f1, uint8_t f2, uint8_t f3, uint8_t f4, uint8_t f5, uint8_t f6,
+                      uint8_t f7, uint8_t f8) {
+  *msg = (CANMessage){
+    .type = type,                                   //
+    .source_id = source_id,                         //
+    .msg_id = id,                                   //
+    .data_u8 = { f1, f2, f3, f4, f5, f6, f7, f8 },  //
+  };
+  msg->dlc = CAN_PACK_CALC_DLC(msg->data);
+}
+
+void can_pack_impl_u16(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
+                       uint16_t f1, uint16_t f2, uint16_t f3, uint16_t f4) {
+  *msg = (CANMessage){
+    .type = type,                    //
+    .source_id = source_id,          //
+    .msg_id = id,                    //
+    .data_u16 = { f1, f2, f3, f4 },  //
+  };
+  msg->dlc = CAN_PACK_CALC_DLC(msg->data);
+}
+
+void can_pack_impl_u32(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
+                       uint32_t f1, uint32_t f2) {
+  *msg = (CANMessage){
+    .type = type,            //
+    .source_id = source_id,  //
+    .msg_id = id,            //
+    .data_u32 = { f1, f2 },  //
+  };
+  msg->dlc = CAN_PACK_CALC_DLC(msg->data);
+}
+
+void can_pack_impl_u64(CANMessage *msg, uint16_t source_id, CANMessageID id, CANMsgType type,
+                       uint64_t f1) {
+  *msg = (CANMessage){
+    .type = type,            //
+    .source_id = source_id,  //
+    .msg_id = id,            //
+    .data = f1,              //
+  };
+  msg->dlc = CAN_PACK_CALC_DLC(msg->data);
+}

--- a/libraries/ms-common/src/can_unpack_impl.c
+++ b/libraries/ms-common/src/can_unpack_impl.c
@@ -10,8 +10,12 @@
     *(f_ptr) = (msg_data);                      \
   }
 
-void can_unpack_impl_u8(const CANMessage *msg, uint8_t *f1, uint8_t *f2, uint8_t *f3, uint8_t *f4,
-                        uint8_t *f5, uint8_t *f6, uint8_t *f7, uint8_t *f8) {
+StatusCode can_unpack_impl_u8(const CANMessage *msg, size_t expected_dlc, uint8_t *f1, uint8_t *f2,
+                              uint8_t *f3, uint8_t *f4, uint8_t *f5, uint8_t *f6, uint8_t *f7,
+                              uint8_t *f8) {
+  if (expected_dlc != msg->dlc) {
+    return status_msg(STATUS_CODE_INTERNAL_ERROR, "DLC mismatch");
+  }
   CAN_UNPACK_IF_NOT_NULL(msg->data_u8[0], f1);
   CAN_UNPACK_IF_NOT_NULL(msg->data_u8[1], f2);
   CAN_UNPACK_IF_NOT_NULL(msg->data_u8[2], f3);
@@ -20,21 +24,35 @@ void can_unpack_impl_u8(const CANMessage *msg, uint8_t *f1, uint8_t *f2, uint8_t
   CAN_UNPACK_IF_NOT_NULL(msg->data_u8[5], f6);
   CAN_UNPACK_IF_NOT_NULL(msg->data_u8[6], f7);
   CAN_UNPACK_IF_NOT_NULL(msg->data_u8[7], f8);
+  return STATUS_CODE_OK;
 }
 
-void can_unpack_impl_u16(const CANMessage *msg, uint16_t *f1, uint16_t *f2, uint16_t *f3,
-                         uint16_t *f4) {
+StatusCode can_unpack_impl_u16(const CANMessage *msg, size_t expected_dlc, uint16_t *f1,
+                               uint16_t *f2, uint16_t *f3, uint16_t *f4) {
+  if (expected_dlc != msg->dlc) {
+    return status_msg(STATUS_CODE_INTERNAL_ERROR, "DLC mismatch");
+  }
   CAN_UNPACK_IF_NOT_NULL(msg->data_u16[0], f1);
   CAN_UNPACK_IF_NOT_NULL(msg->data_u16[1], f2);
   CAN_UNPACK_IF_NOT_NULL(msg->data_u16[2], f3);
   CAN_UNPACK_IF_NOT_NULL(msg->data_u16[3], f4);
+  return STATUS_CODE_OK;
 }
 
-void can_unpack_impl_u32(const CANMessage *msg, uint32_t *f1, uint32_t *f2) {
+StatusCode can_unpack_impl_u32(const CANMessage *msg, size_t expected_dlc, uint32_t *f1,
+                               uint32_t *f2) {
+  if (expected_dlc != msg->dlc) {
+    return status_msg(STATUS_CODE_INTERNAL_ERROR, "DLC mismatch");
+  }
   CAN_UNPACK_IF_NOT_NULL(msg->data_u32[0], f1);
   CAN_UNPACK_IF_NOT_NULL(msg->data_u32[1], f2);
+  return STATUS_CODE_OK;
 }
 
-void can_unpack_impl_u64(const CANMessage *msg, uint64_t *f1) {
+StatusCode can_unpack_impl_u64(const CANMessage *msg, size_t expected_dlc, uint64_t *f1) {
+  if (expected_dlc != msg->dlc) {
+    return status_msg(STATUS_CODE_INTERNAL_ERROR, "DLC mismatch");
+  }
   CAN_UNPACK_IF_NOT_NULL(msg->data, f1);
+  return STATUS_CODE_OK;
 }

--- a/libraries/ms-common/src/can_unpack_impl.c
+++ b/libraries/ms-common/src/can_unpack_impl.c
@@ -1,0 +1,40 @@
+#include "can_unpack_impl.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#include "can_msg.h"
+
+#define CAN_UNPACK_IF_NOT_NULL(msg_data, f_ptr) \
+  if ((f_ptr) != NULL) {                        \
+    *(f_ptr) = (msg_data);                      \
+  }
+
+void can_unpack_impl_u8(const CANMessage *msg, uint8_t *f1, uint8_t *f2, uint8_t *f3, uint8_t *f4,
+                        uint8_t *f5, uint8_t *f6, uint8_t *f7, uint8_t *f8) {
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u8[0], f1);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u8[1], f2);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u8[2], f3);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u8[3], f4);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u8[4], f5);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u8[5], f6);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u8[6], f7);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u8[7], f8);
+}
+
+void can_unpack_impl_u16(const CANMessage *msg, uint16_t *f1, uint16_t *f2, uint16_t *f3,
+                         uint16_t *f4) {
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u16[0], f1);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u16[1], f2);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u16[2], f3);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u16[3], f4);
+}
+
+void can_unpack_impl_u32(const CANMessage *msg, uint32_t *f1, uint32_t *f2) {
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u32[0], f1);
+  CAN_UNPACK_IF_NOT_NULL(msg->data_u32[1], f2);
+}
+
+void can_unpack_impl_u64(const CANMessage *msg, uint64_t *f1) {
+  CAN_UNPACK_IF_NOT_NULL(msg->data, f1);
+}

--- a/libraries/ms-common/test/test_can_pack_impl.c
+++ b/libraries/ms-common/test/test_can_pack_impl.c
@@ -1,0 +1,65 @@
+#include "can_pack_impl.h"
+
+#include <stdint.h>
+#include <stdio.h>
+
+#include "can_msg.h"
+#include "unity.h"
+
+#define TEST_CAN_PACK_IMPL_MAX_DLC 8
+#define TEST_CAN_PACK_ID 1
+#define TEST_CAN_PACK_SOURCE_ID 1
+#define TEST_CAN_PACK_TYPE CAN_MSG_TYPE_DATA
+
+// Since all the methods use the same test framework just define it as a macro to reduce redundant
+// code. It is a bit magic but it is relatively understandable if you realize macros are just
+// replaced with what they represent at compile time.
+#define TEST_CAN_PACK_IMPL_FRAMEWORK(pack_call)                   \
+  do {                                                            \
+    CANMessage msg = { 0 };                                       \
+    test_can_pack_impl_data data = {.data_u64 = 1 };              \
+    for (size_t i = 0; i < TEST_CAN_PACK_IMPL_MAX_DLC; i++) {     \
+      (pack_call);                                                \
+      TEST_ASSERT_EQUAL_UINT64(data.data_u64, msg.data);          \
+      TEST_ASSERT_EQUAL(TEST_CAN_PACK_IMPL_MAX_DLC - i, msg.dlc); \
+      TEST_ASSERT_EQUAL(TEST_CAN_PACK_SOURCE_ID, msg.source_id);  \
+      TEST_ASSERT_EQUAL(TEST_CAN_PACK_ID, msg.msg_id);            \
+      TEST_ASSERT_EQUAL(TEST_CAN_PACK_TYPE, msg.type);            \
+      data.data_u64 <<= 8;                                        \
+    }                                                             \
+  } while (0)
+
+typedef union test_can_pack_impl_data {
+  uint64_t data_u64;
+  uint32_t data_u32[2];
+  uint16_t data_u16[4];
+  uint8_t data_u8[8];
+} test_can_pack_impl_data;
+
+void setup_test(void) {}
+
+void teardown_test(void) {}
+
+void test_can_pack_impl_u8(void) {
+  TEST_CAN_PACK_IMPL_FRAMEWORK(
+      can_pack_impl_u8(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID, TEST_CAN_PACK_TYPE,
+                       data.data_u8[0], data.data_u8[1], data.data_u8[2], data.data_u8[3],
+                       data.data_u8[4], data.data_u8[5], data.data_u8[6], data.data_u8[7]));
+}
+
+void test_can_pack_impl_u16(void) {
+  TEST_CAN_PACK_IMPL_FRAMEWORK(
+      can_pack_impl_u16(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID, TEST_CAN_PACK_TYPE,
+                        data.data_u16[0], data.data_u16[1], data.data_u16[2], data.data_u16[3]));
+}
+
+void test_can_pack_impl_u32(void) {
+  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u32(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
+                                                 TEST_CAN_PACK_TYPE, data.data_u32[0],
+                                                 data.data_u32[1]));
+}
+
+void test_can_pack_impl_u64(void) {
+  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u64(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
+                                                 TEST_CAN_PACK_TYPE, data.data_u64));
+}

--- a/libraries/ms-common/test/test_can_pack_impl.c
+++ b/libraries/ms-common/test/test_can_pack_impl.c
@@ -4,9 +4,10 @@
 #include <stdio.h>
 
 #include "can_msg.h"
+#include "status.h"
+#include "test_helpers.h"
 #include "unity.h"
 
-#define TEST_CAN_PACK_IMPL_MAX_DLC 8
 #define TEST_CAN_PACK_ID 1
 #define TEST_CAN_PACK_SOURCE_ID 1
 #define TEST_CAN_PACK_TYPE CAN_MSG_TYPE_DATA
@@ -14,19 +15,22 @@
 // Since all the methods use the same test framework just define it as a macro to reduce redundant
 // code. It is a bit magic but it is relatively understandable if you realize macros are just
 // replaced with what they represent at compile time.
-#define TEST_CAN_PACK_IMPL_FRAMEWORK(pack_call)                   \
-  do {                                                            \
-    CANMessage msg = { 0 };                                       \
-    test_can_pack_impl_data data = {.data_u64 = 1 };              \
-    for (size_t i = 0; i < TEST_CAN_PACK_IMPL_MAX_DLC; i++) {     \
-      (pack_call);                                                \
-      TEST_ASSERT_EQUAL_UINT64(data.data_u64, msg.data);          \
-      TEST_ASSERT_EQUAL(TEST_CAN_PACK_IMPL_MAX_DLC - i, msg.dlc); \
-      TEST_ASSERT_EQUAL(TEST_CAN_PACK_SOURCE_ID, msg.source_id);  \
-      TEST_ASSERT_EQUAL(TEST_CAN_PACK_ID, msg.msg_id);            \
-      TEST_ASSERT_EQUAL(TEST_CAN_PACK_TYPE, msg.type);            \
-      data.data_u64 <<= 8;                                        \
-    }                                                             \
+#define TEST_CAN_PACK_IMPL_FRAMEWORK(pack_call)                  \
+  do {                                                           \
+    CANMessage msg = { 0 };                                      \
+    test_can_pack_impl_data data = {.data_u64 = 1 };             \
+    size_t size;                                                 \
+    for (size = 0; size < CAN_PACK_IMPL_MAX_DLC; size++) {       \
+      TEST_ASSERT_OK((pack_call));                               \
+      TEST_ASSERT_EQUAL_UINT64(data.data_u64, msg.data);         \
+      TEST_ASSERT_EQUAL(size, msg.dlc);                          \
+      TEST_ASSERT_EQUAL(TEST_CAN_PACK_SOURCE_ID, msg.source_id); \
+      TEST_ASSERT_EQUAL(TEST_CAN_PACK_ID, msg.msg_id);           \
+      TEST_ASSERT_EQUAL(TEST_CAN_PACK_TYPE, msg.type);           \
+      data.data_u64 <<= 8;                                       \
+    }                                                            \
+    ++size;                                                      \
+    TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, (pack_call));    \
   } while (0)
 
 typedef union test_can_pack_impl_data {
@@ -42,23 +46,23 @@ void teardown_test(void) {}
 
 void test_can_pack_impl_u8(void) {
   TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u8(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
-                                                data.data_u8[0], data.data_u8[1], data.data_u8[2],
-                                                data.data_u8[3], data.data_u8[4], data.data_u8[5],
-                                                data.data_u8[6], data.data_u8[7]));
+                                                size, data.data_u8[0], data.data_u8[1],
+                                                data.data_u8[2], data.data_u8[3], data.data_u8[4],
+                                                data.data_u8[5], data.data_u8[6], data.data_u8[7]));
 }
 
 void test_can_pack_impl_u16(void) {
   TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u16(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
-                                                 data.data_u16[0], data.data_u16[1],
+                                                 size, data.data_u16[0], data.data_u16[1],
                                                  data.data_u16[2], data.data_u16[3]));
 }
 
 void test_can_pack_impl_u32(void) {
   TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u32(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
-                                                 data.data_u32[0], data.data_u32[1]));
+                                                 size, data.data_u32[0], data.data_u32[1]));
 }
 
 void test_can_pack_impl_u64(void) {
   TEST_CAN_PACK_IMPL_FRAMEWORK(
-      can_pack_impl_u64(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID, data.data_u64));
+      can_pack_impl_u64(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID, size, data.data_u64));
 }

--- a/libraries/ms-common/test/test_can_pack_impl.c
+++ b/libraries/ms-common/test/test_can_pack_impl.c
@@ -54,11 +54,11 @@ void test_can_pack_impl_u16(void) {
 }
 
 void test_can_pack_impl_u32(void) {
-  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u32(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_TYPE,
+  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u32(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
                                                  data.data_u32[0], data.data_u32[1]));
 }
 
 void test_can_pack_impl_u64(void) {
   TEST_CAN_PACK_IMPL_FRAMEWORK(
-      can_pack_impl_u64(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_TYPE, data.data_u64));
+      can_pack_impl_u64(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID, data.data_u64));
 }

--- a/libraries/ms-common/test/test_can_pack_impl.c
+++ b/libraries/ms-common/test/test_can_pack_impl.c
@@ -41,25 +41,24 @@ void setup_test(void) {}
 void teardown_test(void) {}
 
 void test_can_pack_impl_u8(void) {
-  TEST_CAN_PACK_IMPL_FRAMEWORK(
-      can_pack_impl_u8(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID, TEST_CAN_PACK_TYPE,
-                       data.data_u8[0], data.data_u8[1], data.data_u8[2], data.data_u8[3],
-                       data.data_u8[4], data.data_u8[5], data.data_u8[6], data.data_u8[7]));
+  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u8(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
+                                                data.data_u8[0], data.data_u8[1], data.data_u8[2],
+                                                data.data_u8[3], data.data_u8[4], data.data_u8[5],
+                                                data.data_u8[6], data.data_u8[7]));
 }
 
 void test_can_pack_impl_u16(void) {
-  TEST_CAN_PACK_IMPL_FRAMEWORK(
-      can_pack_impl_u16(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID, TEST_CAN_PACK_TYPE,
-                        data.data_u16[0], data.data_u16[1], data.data_u16[2], data.data_u16[3]));
+  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u16(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
+                                                 data.data_u16[0], data.data_u16[1],
+                                                 data.data_u16[2], data.data_u16[3]));
 }
 
 void test_can_pack_impl_u32(void) {
-  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u32(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
-                                                 TEST_CAN_PACK_TYPE, data.data_u32[0],
-                                                 data.data_u32[1]));
+  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u32(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_TYPE,
+                                                 data.data_u32[0], data.data_u32[1]));
 }
 
 void test_can_pack_impl_u64(void) {
-  TEST_CAN_PACK_IMPL_FRAMEWORK(can_pack_impl_u64(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_ID,
-                                                 TEST_CAN_PACK_TYPE, data.data_u64));
+  TEST_CAN_PACK_IMPL_FRAMEWORK(
+      can_pack_impl_u64(&msg, TEST_CAN_PACK_SOURCE_ID, TEST_CAN_PACK_TYPE, data.data_u64));
 }

--- a/libraries/ms-common/test/test_can_unpack_impl.c
+++ b/libraries/ms-common/test/test_can_unpack_impl.c
@@ -1,0 +1,44 @@
+#include "can_unpack_impl.h"
+
+#include <stdint.h>
+
+#include "can_msg.h"
+#include "misc.h"
+#include "unity.h"
+
+static const CANMessage s_msg = {
+  .data_u8 = { 32, 64, 29, 76, 56, 21, 3, 1 },
+};
+
+void setup_test(void) {}
+
+void teardown_test(void) {}
+
+void test_can_unpack_impl_u8(void) {
+  uint8_t f[8] = { 0 };
+  can_unpack_impl_u8(&s_msg, &f[0], &f[1], &f[2], &f[3], &f[4], &f[5], &f[6], &f[7]);
+  TEST_ASSERT_EQUAL_UINT8_ARRAY(s_msg.data_u8, f, SIZEOF_ARRAY(s_msg.data_u8));
+  can_unpack_impl_u8(&s_msg, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+                     NULL);  // Ensure it doesn't segfault.
+}
+
+void test_can_unpack_impl_u16(void) {
+  uint16_t f[4] = { 0 };
+  can_unpack_impl_u16(&s_msg, &f[0], &f[1], &f[2], &f[3]);
+  TEST_ASSERT_EQUAL_UINT16_ARRAY(s_msg.data_u16, f, SIZEOF_ARRAY(s_msg.data_u16));
+  can_unpack_impl_u16(&s_msg, NULL, NULL, NULL, NULL);  // Ensure it doesn't segfault.
+}
+
+void test_can_unpack_impl_u32(void) {
+  uint32_t f[2] = { 0 };
+  can_unpack_impl_u32(&s_msg, &f[0], &f[1]);
+  TEST_ASSERT_EQUAL_UINT32_ARRAY(s_msg.data_u32, f, SIZEOF_ARRAY(s_msg.data_u32));
+  can_unpack_impl_u32(&s_msg, NULL, NULL);  // Ensure it doesn't segfault.
+}
+
+void test_can_unpack_impl_u64(void) {
+  uint64_t f = 0;
+  can_unpack_impl_u64(&s_msg, &f);
+  TEST_ASSERT_EQUAL_UINT64(s_msg.data, f);
+  can_unpack_impl_u64(&s_msg, NULL);  // Ensure it doesn't segfault.
+}

--- a/libraries/ms-common/test/test_can_unpack_impl.c
+++ b/libraries/ms-common/test/test_can_unpack_impl.c
@@ -23,9 +23,9 @@ void test_can_unpack_impl_u8(void) {
                      NULL);  // Ensure it doesn't segfault.
 
   memset(&f, 0, sizeof(f));
-  can_unpack_impl_u8(&s_msg, &f[0], &f[1], &f[2], NULL, NULL, NULL, NULL, NULL);
+  can_unpack_impl_u8(&s_msg, &f[0], NULL, &f[2], NULL, NULL, &f[5], NULL, NULL);
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[0], f[0]);
-  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[1], f[1]);
+  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[5], f[5]);
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[2], f[2]);
 }
 
@@ -36,9 +36,8 @@ void test_can_unpack_impl_u16(void) {
   can_unpack_impl_u16(&s_msg, NULL, NULL, NULL, NULL);  // Ensure it doesn't segfault.
 
   memset(&f, 0, sizeof(f));
-  can_unpack_impl_u16(&s_msg, &f[0], &f[1], &f[2], NULL);
+  can_unpack_impl_u16(&s_msg, &f[0], NULL, &f[2], NULL);
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[0], f[0]);
-  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[1], f[1]);
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[2], f[2]);
 }
 

--- a/libraries/ms-common/test/test_can_unpack_impl.c
+++ b/libraries/ms-common/test/test_can_unpack_impl.c
@@ -1,6 +1,7 @@
 #include "can_unpack_impl.h"
 
 #include <stdint.h>
+#include <string.h>
 
 #include "can_msg.h"
 #include "misc.h"
@@ -20,6 +21,12 @@ void test_can_unpack_impl_u8(void) {
   TEST_ASSERT_EQUAL_UINT8_ARRAY(s_msg.data_u8, f, SIZEOF_ARRAY(s_msg.data_u8));
   can_unpack_impl_u8(&s_msg, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
                      NULL);  // Ensure it doesn't segfault.
+
+  memset(&f, 0, sizeof(f));
+  can_unpack_impl_u8(&s_msg, &f[0], &f[1], &f[2], NULL, NULL, NULL, NULL, NULL);
+  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[0], f[0]);
+  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[1], f[1]);
+  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[2], f[2]);
 }
 
 void test_can_unpack_impl_u16(void) {
@@ -27,6 +34,12 @@ void test_can_unpack_impl_u16(void) {
   can_unpack_impl_u16(&s_msg, &f[0], &f[1], &f[2], &f[3]);
   TEST_ASSERT_EQUAL_UINT16_ARRAY(s_msg.data_u16, f, SIZEOF_ARRAY(s_msg.data_u16));
   can_unpack_impl_u16(&s_msg, NULL, NULL, NULL, NULL);  // Ensure it doesn't segfault.
+
+  memset(&f, 0, sizeof(f));
+  can_unpack_impl_u16(&s_msg, &f[0], &f[1], &f[2], NULL);
+  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[0], f[0]);
+  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[1], f[1]);
+  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[2], f[2]);
 }
 
 void test_can_unpack_impl_u32(void) {
@@ -34,6 +47,10 @@ void test_can_unpack_impl_u32(void) {
   can_unpack_impl_u32(&s_msg, &f[0], &f[1]);
   TEST_ASSERT_EQUAL_UINT32_ARRAY(s_msg.data_u32, f, SIZEOF_ARRAY(s_msg.data_u32));
   can_unpack_impl_u32(&s_msg, NULL, NULL);  // Ensure it doesn't segfault.
+
+  memset(&f, 0, sizeof(f));
+  can_unpack_impl_u32(&s_msg, &f[0], NULL);
+  TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[0], f[0]);
 }
 
 void test_can_unpack_impl_u64(void) {

--- a/libraries/ms-common/test/test_can_unpack_impl.c
+++ b/libraries/ms-common/test/test_can_unpack_impl.c
@@ -5,10 +5,15 @@
 
 #include "can_msg.h"
 #include "misc.h"
+#include "status.h"
+#include "test_helpers.h"
 #include "unity.h"
 
+#define TEST_CAN_UNPACK_IMPL_DLC 8
+
 static const CANMessage s_msg = {
-  .data_u8 = { 32, 64, 29, 76, 56, 21, 3, 1 },
+  .data_u8 = { 32, 64, 29, 76, 56, 21, 3, 1 },  //
+  .dlc = TEST_CAN_UNPACK_IMPL_DLC,              //
 };
 
 void setup_test(void) {}
@@ -17,44 +22,64 @@ void teardown_test(void) {}
 
 void test_can_unpack_impl_u8(void) {
   uint8_t f[8] = { 0 };
-  can_unpack_impl_u8(&s_msg, &f[0], &f[1], &f[2], &f[3], &f[4], &f[5], &f[6], &f[7]);
+  TEST_ASSERT_OK(can_unpack_impl_u8(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, &f[0], &f[1], &f[2], &f[3],
+                                    &f[4], &f[5], &f[6], &f[7]));
   TEST_ASSERT_EQUAL_UINT8_ARRAY(s_msg.data_u8, f, SIZEOF_ARRAY(s_msg.data_u8));
-  can_unpack_impl_u8(&s_msg, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
-                     NULL);  // Ensure it doesn't segfault.
+  TEST_ASSERT_OK(can_unpack_impl_u8(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, NULL, NULL, NULL, NULL, NULL,
+                                    NULL, NULL,
+                                    NULL));  // Ensure it doesn't segfault.
 
   memset(&f, 0, sizeof(f));
-  can_unpack_impl_u8(&s_msg, &f[0], NULL, &f[2], NULL, NULL, &f[5], NULL, NULL);
+  TEST_ASSERT_OK(can_unpack_impl_u8(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, &f[0], NULL, &f[2], NULL,
+                                    NULL, &f[5], NULL, NULL));
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[0], f[0]);
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[5], f[5]);
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u8[2], f[2]);
+
+  TEST_ASSERT_EQUAL(STATUS_CODE_INTERNAL_ERROR,
+                    can_unpack_impl_u8(&s_msg, TEST_CAN_UNPACK_IMPL_DLC - 1, NULL, NULL, NULL, NULL,
+                                       NULL, NULL, NULL, NULL));
 }
 
 void test_can_unpack_impl_u16(void) {
   uint16_t f[4] = { 0 };
-  can_unpack_impl_u16(&s_msg, &f[0], &f[1], &f[2], &f[3]);
+  TEST_ASSERT_OK(can_unpack_impl_u16(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, &f[0], &f[1], &f[2], &f[3]));
   TEST_ASSERT_EQUAL_UINT16_ARRAY(s_msg.data_u16, f, SIZEOF_ARRAY(s_msg.data_u16));
-  can_unpack_impl_u16(&s_msg, NULL, NULL, NULL, NULL);  // Ensure it doesn't segfault.
+  TEST_ASSERT_OK(can_unpack_impl_u16(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, NULL, NULL, NULL,
+                                     NULL));  // Ensure it doesn't segfault.
 
   memset(&f, 0, sizeof(f));
-  can_unpack_impl_u16(&s_msg, &f[0], NULL, &f[2], NULL);
+  TEST_ASSERT_OK(can_unpack_impl_u16(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, &f[0], NULL, &f[2], NULL));
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[0], f[0]);
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[2], f[2]);
+
+  TEST_ASSERT_EQUAL(
+      STATUS_CODE_INTERNAL_ERROR,
+      can_unpack_impl_u16(&s_msg, TEST_CAN_UNPACK_IMPL_DLC - 1, NULL, NULL, NULL, NULL));
 }
 
 void test_can_unpack_impl_u32(void) {
   uint32_t f[2] = { 0 };
-  can_unpack_impl_u32(&s_msg, &f[0], &f[1]);
+  TEST_ASSERT_OK(can_unpack_impl_u32(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, &f[0], &f[1]));
   TEST_ASSERT_EQUAL_UINT32_ARRAY(s_msg.data_u32, f, SIZEOF_ARRAY(s_msg.data_u32));
-  can_unpack_impl_u32(&s_msg, NULL, NULL);  // Ensure it doesn't segfault.
+  TEST_ASSERT_OK(can_unpack_impl_u32(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, NULL,
+                                     NULL));  // Ensure it doesn't segfault.
 
   memset(&f, 0, sizeof(f));
-  can_unpack_impl_u32(&s_msg, &f[0], NULL);
+  TEST_ASSERT_OK(can_unpack_impl_u32(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, &f[0], NULL));
   TEST_ASSERT_EQUAL_UINT8(s_msg.data_u16[0], f[0]);
+
+  TEST_ASSERT_EQUAL(STATUS_CODE_INTERNAL_ERROR,
+                    can_unpack_impl_u32(&s_msg, TEST_CAN_UNPACK_IMPL_DLC - 1, NULL, NULL));
 }
 
 void test_can_unpack_impl_u64(void) {
   uint64_t f = 0;
-  can_unpack_impl_u64(&s_msg, &f);
+  TEST_ASSERT_OK(can_unpack_impl_u64(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, &f));
   TEST_ASSERT_EQUAL_UINT64(s_msg.data, f);
-  can_unpack_impl_u64(&s_msg, NULL);  // Ensure it doesn't segfault.
+  TEST_ASSERT_OK(
+      can_unpack_impl_u64(&s_msg, TEST_CAN_UNPACK_IMPL_DLC, NULL));  // Ensure it doesn't segfault.
+
+  TEST_ASSERT_EQUAL(STATUS_CODE_INTERNAL_ERROR,
+                    can_unpack_impl_u64(&s_msg, TEST_CAN_UNPACK_IMPL_DLC - 1, NULL));
 }


### PR DESCRIPTION
This PR is the backend (firmware) component of the work required for ELEC-274 which will add templates to codegen to automatically generate boilerplate macros for each message to pack, unpack and transmit using verbose field/message names and automatically masking and populating the message id, source id and type fields. The reason these are `*_impl` is because they are internals that should not be called in modules other than `can_pack` and `can_unpack` which will be generate by templates.

CAN pack is very straightforward other than the fact that the `dlc` field is set to the minimum required bytes to convey the message. This means if the last fields are 0s they will not be sent. However, since we are using codegen this isn't an issue in determining how large the data field is since when unpacking the receiver will automatically unpack the correct number of fields thanks to the codegen boilerplate.

CAN unpack only unpacks the fields as it is relatively easy to access the ID/source if required by de-referencing the struct. Hopefully, this should be unnecessary as dedicated handlers should be provided for most CAN messages except on driver display and telemetry which will read every message anyway. 

The generated transmit macros will build and send the ACK request so the only remaining issue to solve is how the receiver knows to responds to an ACK.