### PR TITLE
ELEC-280: CAN ACK device bitset

### DIFF
--- a/libraries/libcore/inc/misc.h
+++ b/libraries/libcore/inc/misc.h
@@ -2,6 +2,7 @@
 // Common helper macros
 
 #define SIZEOF_ARRAY(arr) (sizeof((arr)) / sizeof((arr)[0]))
+#define SIZEOF_FIELD(type, field) (sizeof(((type *)0)->field))
 // Casts void * to uint8_t *
 #define VOID_PTR_UINT8(x) (_Generic((x), void * : (uint8_t *)(x), default : (x)))
 

--- a/libraries/ms-common/inc/can_ack.h
+++ b/libraries/ms-common/inc/can_ack.h
@@ -10,6 +10,8 @@
 //
 // If the ACK has timed out or we've received the expected number of ACKs, we remove the ACK request
 // from the list. We use an object pool and an array of pointers to do so efficiently.
+#include <assert.h>
+#include <limits.h>
 #include "can_msg.h"
 #include "objpool.h"
 #include "soft_timer.h"
@@ -18,8 +20,19 @@
 // ACK timeout: Should account for transit and computation time
 // Note that this timeout is currently an arbitrary value, but should be minimized.
 #define CAN_ACK_TIMEOUT_MS 10
-
 #define CAN_ACK_MAX_REQUESTS 10
+
+// Converts devices IDs to their bitset form. Populate ACK request bitsets using this.
+// Example: ack_request.expected_bitset = CAN_ACK_EXPECTED_DEVICES(CAN_DEVICE_A, CAN_DEVICE_D)
+#define CAN_ACK_EXPECTED_DEVICES(...)                       \
+  ({                                                        \
+    uint32_t device_ids[] = { __VA_ARGS__ };                \
+    uint32_t bitset = 0;                                    \
+    for (size_t i = 0; i < SIZEOF_ARRAY(device_ids); i++) { \
+      bitset |= ((uint32_t)1 << device_ids[i]);             \
+    }                                                       \
+    bitset;                                                 \
+  })
 
 typedef enum {
   CAN_ACK_STATUS_OK = 0,
@@ -38,17 +51,24 @@ typedef StatusCode (*CANAckRequestCb)(CANMessageID msg_id, uint16_t device, CANA
 typedef struct CANAckRequest {
   CANAckRequestCb callback;
   void *context;
-  uint16_t num_expected;
+  uint32_t expected_bitset;
 } CANAckRequest;
+static_assert(SIZEOF_FIELD(CANAckRequest, expected_bitset) * CHAR_BIT >= CAN_MSG_MAX_DEVICES,
+              "CAN ACK request expected bitset field not large enough to fit all CAN devices!");
 
 typedef struct CANAckPendingReq {
-  CANMessageID msg_id;
-  uint16_t num_remaining;
   CANAckRequestCb callback;
   void *context;
-  SoftTimerID timer;
+  uint32_t expected_bitset;
   uint32_t response_bitset;
+  SoftTimerID timer;
+  CANMessageID msg_id;
 } CANAckPendingReq;
+static_assert(SIZEOF_FIELD(CANAckPendingReq, expected_bitset) * CHAR_BIT >= CAN_MSG_MAX_DEVICES,
+              "CAN pending ACK expected bitset field not large enough to fit all CAN devices!");
+static_assert(SIZEOF_FIELD(CANAckPendingReq, expected_bitset) ==
+                  SIZEOF_FIELD(CANAckPendingReq, response_bitset),
+              "CAN pending ACK expected bitset size not equal to response bitset size");
 
 typedef struct CANAckRequests {
   ObjectPool pool;
@@ -59,6 +79,7 @@ typedef struct CANAckRequests {
 
 StatusCode can_ack_init(CANAckRequests *requests);
 
+// ack_request's expected bitset should be populated using CAN_ACK_EXPECTED_DEVICES.
 StatusCode can_ack_add_request(CANAckRequests *requests, CANMessageID msg_id,
                                const CANAckRequest *ack_request);
 

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -154,9 +154,9 @@ void test_can_ack(void) {
   };
 
   CANAckRequest ack_req = {
-    .callback = prv_ack_callback,  //
-    .context = &device_acked,      //
-    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),             //
+    .callback = prv_ack_callback,                                     //
+    .context = &device_acked,                                         //
+    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),  //
   };
 
   StatusCode ret = can_transmit(&msg, &ack_req);
@@ -192,9 +192,9 @@ void test_can_ack_expire(void) {
   };
 
   CANAckRequest ack_req = {
-    .callback = prv_ack_callback_status,  //
-    .context = &ack_status,               //
-    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),                    //
+    .callback = prv_ack_callback_status,                              //
+    .context = &ack_status,                                           //
+    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),  //
   };
 
   StatusCode ret = can_transmit(&msg, &ack_req);
@@ -217,9 +217,9 @@ void test_can_ack_status(void) {
   };
 
   CANAckRequest ack_req = {
-    .callback = prv_ack_callback_status,  //
-    .context = &ack_status,               //
-    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),                    //
+    .callback = prv_ack_callback_status,                              //
+    .context = &ack_status,                                           //
+    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),  //
   };
 
   can_register_rx_handler(TEST_CAN_UNKNOWN_MSG_ID, prv_rx_callback, &rx_msg);

--- a/libraries/ms-common/test/test_can.c
+++ b/libraries/ms-common/test/test_can.c
@@ -156,7 +156,7 @@ void test_can_ack(void) {
   CANAckRequest ack_req = {
     .callback = prv_ack_callback,  //
     .context = &device_acked,      //
-    .num_expected = 1,             //
+    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),             //
   };
 
   StatusCode ret = can_transmit(&msg, &ack_req);
@@ -194,7 +194,7 @@ void test_can_ack_expire(void) {
   CANAckRequest ack_req = {
     .callback = prv_ack_callback_status,  //
     .context = &ack_status,               //
-    .num_expected = 4,                    //
+    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),                    //
   };
 
   StatusCode ret = can_transmit(&msg, &ack_req);
@@ -219,7 +219,7 @@ void test_can_ack_status(void) {
   CANAckRequest ack_req = {
     .callback = prv_ack_callback_status,  //
     .context = &ack_status,               //
-    .num_expected = 1,                    //
+    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_DEVICE_ID),                    //
   };
 
   can_register_rx_handler(TEST_CAN_UNKNOWN_MSG_ID, prv_rx_callback, &rx_msg);

--- a/libraries/ms-common/test/test_can_ack.c
+++ b/libraries/ms-common/test/test_can_ack.c
@@ -5,7 +5,13 @@
 #include "test_helpers.h"
 #include "unity.h"
 
-#define TEST_CAN_ACK_INVALID_DEVICE 10
+typedef enum {
+  TEST_CAN_ACK_DEVICE_A = 0,
+  TEST_CAN_ACK_DEVICE_B,
+  TEST_CAN_ACK_DEVICE_C,
+  TEST_CAN_ACK_DEVICE_INVALID,
+  TEST_CAN_ACK_DEVICE_UNRECOGNIZED
+} TestCanAckDevice;
 
 static CANAckRequests s_ack_requests;
 
@@ -26,7 +32,7 @@ static StatusCode prv_ack_callback(CANMessageID msg_id, uint16_t device, CANAckS
   data->status = status;
   data->num_remaining = num_remaining;
 
-  if (device == TEST_CAN_ACK_INVALID_DEVICE) {
+  if (device == TEST_CAN_ACK_DEVICE_INVALID) {
     LOG_DEBUG("Returning unknown code\n");
     return status_code(STATUS_CODE_UNKNOWN);
   }
@@ -45,31 +51,32 @@ void teardown_test(void) {}
 void test_can_ack_handle_devices(void) {
   TestResponse data = { 0 };
   CANMessage can_msg = {
-    .source_id = 0,            //
-    .type = CAN_MSG_TYPE_ACK,  //
-    .msg_id = 0,               //
+    .source_id = TEST_CAN_ACK_DEVICE_A,  //
+    .type = CAN_MSG_TYPE_ACK,            //
+    .msg_id = 0x2,                       //
   };
   CANAckRequest ack_request = {
-    .callback = prv_ack_callback, .context = &data,
+    .callback = prv_ack_callback,  //
+    .context = &data,              //
   };
 
-  ack_request.num_expected = 6;
+  ack_request.expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_ACK_DEVICE_A);
   can_ack_add_request(&s_ack_requests, 0x4, &ack_request);
-  ack_request.num_expected = 3;
+  ack_request.expected_bitset =
+      CAN_ACK_EXPECTED_DEVICES(TEST_CAN_ACK_DEVICE_A, TEST_CAN_ACK_DEVICE_B, TEST_CAN_ACK_DEVICE_C,
+                               TEST_CAN_ACK_DEVICE_INVALID);
   can_ack_add_request(&s_ack_requests, 0x2, &ack_request);
-  ack_request.num_expected = 6;
   can_ack_add_request(&s_ack_requests, 0x6, &ack_request);
-  ack_request.num_expected = 1;
+  ack_request.expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_ACK_DEVICE_A);
   can_ack_add_request(&s_ack_requests, 0x2, &ack_request);
 
-  can_msg.msg_id = 0x2;
   LOG_DEBUG("Handling ACK for ID %d, device %d\n", can_msg.msg_id, can_msg.source_id);
   StatusCode ret = can_ack_handle_msg(&s_ack_requests, &can_msg);
   TEST_ASSERT_OK(ret);
 
   // Expect to update the 1st 0x2 ACK request
   TEST_ASSERT_EQUAL(can_msg.msg_id, data.msg_id);
-  TEST_ASSERT_EQUAL(2, data.num_remaining);
+  TEST_ASSERT_EQUAL(3, data.num_remaining);
 
   LOG_DEBUG("Handling duplicate ACK\n");
   ret = can_ack_handle_msg(&s_ack_requests, &can_msg);
@@ -84,30 +91,38 @@ void test_can_ack_handle_devices(void) {
   ret = can_ack_handle_msg(&s_ack_requests, &can_msg);
   TEST_ASSERT_EQUAL(STATUS_CODE_UNKNOWN, ret);
 
-  // Valid ACK (new device)
-  can_msg.source_id = 1;
+  // Valid ACK (new device) - 0x2
+  can_msg.source_id = TEST_CAN_ACK_DEVICE_B;
   LOG_DEBUG("Handling ACK for ID %d, device %d\n", can_msg.msg_id, can_msg.source_id);
   ret = can_ack_handle_msg(&s_ack_requests, &can_msg);
   TEST_ASSERT_OK(ret);
 
   TEST_ASSERT_EQUAL(can_msg.msg_id, data.msg_id);
-  TEST_ASSERT_EQUAL(1, data.num_remaining);
+  TEST_ASSERT_EQUAL(2, data.num_remaining);
 
   // Send invalid device ACK - should be able to send another ACK
-  can_msg.source_id = TEST_CAN_ACK_INVALID_DEVICE;
+  can_msg.source_id = TEST_CAN_ACK_DEVICE_INVALID;
   LOG_DEBUG("Handling ACK from invalid device\n");
   ret = can_ack_handle_msg(&s_ack_requests, &can_msg);
   TEST_ASSERT_OK(ret);
+  TEST_ASSERT_EQUAL(1, data.num_remaining);
 
-  can_msg.source_id = 2;
+  // Unrecognized device ACK - should just be ignored
+  can_msg.source_id = TEST_CAN_ACK_DEVICE_UNRECOGNIZED;
+  LOG_DEBUG("Handling ACK from unrecognized device\n");
+  ret = can_ack_handle_msg(&s_ack_requests, &can_msg);
+  TEST_ASSERT_NOT_OK(ret);
+
+  // 0x2, valid ACK - should still have 1 remaining
+  can_msg.source_id = TEST_CAN_ACK_DEVICE_C;
   LOG_DEBUG("Handling ACK from valid device\n");
   ret = can_ack_handle_msg(&s_ack_requests, &can_msg);
   TEST_ASSERT_OK(ret);
 
-  TEST_ASSERT_EQUAL(0, data.num_remaining);
+  TEST_ASSERT_EQUAL(1, data.num_remaining);
 
-  // 2 ACK requests should be removed
-  TEST_ASSERT_EQUAL(2, s_ack_requests.num_requests);
+  // 1 ACK requests should be removed
+  TEST_ASSERT_EQUAL(3, s_ack_requests.num_requests);
 }
 
 void test_can_ack_expiry(void) {
@@ -116,7 +131,7 @@ void test_can_ack_expiry(void) {
   CANAckRequest ack_request = {
     .callback = prv_ack_callback,  //
     .context = &data,              //
-    .num_expected = 5,             //
+    .expected_bitset = 0x1,        //
   };
 
   can_ack_add_request(&s_ack_requests, 0x2, &ack_request);
@@ -133,18 +148,17 @@ void test_can_ack_expiry_moved(void) {
   // Ensure that ACK expiry can handle being shuffled around
   volatile TestResponse data = { 0 };
   CANMessage can_msg = {
-    .source_id = 0,            //
-    .type = CAN_MSG_TYPE_ACK,  //
-    .msg_id = 0x4,             //
+    .source_id = TEST_CAN_ACK_DEVICE_A,  //
+    .type = CAN_MSG_TYPE_ACK,            //
+    .msg_id = 0x4,                       //
   };
   CANAckRequest ack_request = {
-    .callback = prv_ack_callback,  //
-    .context = &data,              //
-    .num_expected = 1,             //
+    .callback = prv_ack_callback,                                        //
+    .context = &data,                                                    //
+    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_CAN_ACK_DEVICE_A),  //
   };
 
   can_ack_add_request(&s_ack_requests, 0x4, &ack_request);
-  ack_request.num_expected = 5;
   can_ack_add_request(&s_ack_requests, 0x2, &ack_request);
 
   StatusCode ret = can_ack_handle_msg(&s_ack_requests, &can_msg);


### PR DESCRIPTION
Switched from `num_expected` to expected device bitset.

Added variadic macro `CAN_ACK_EXPECTED_DEVICES(...)` to reduce the number of macros we need. I figure people will get confused and use the wrong macro.