### PR TITLE
ELEC-288: Fix race condition in wait.h for the stm32f0xx

### DIFF
--- a/libraries/ms-common/src/stm32f0xx/wait.c
+++ b/libraries/ms-common/src/stm32f0xx/wait.c
@@ -1,7 +1,12 @@
 #include "wait.h"
 
+#include <stdbool.h>
+
+#include "critical_section.h"
 #include "stm32f0xx.h"
 
 void wait(void) {
+  bool disabled = critical_section_start();
   __WFI();
+  critical_section_end(disabled);
 }


### PR DESCRIPTION
Very simple PR that protects the `__WFI()` call in `stm32f0xx/wait.c` by surrounding it in a critical section. 