### PR TITLE
ELEC-313: Speed up Travis CI builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ before_script:
   - make install
   - cd ..
   - rm -rf make-4.1
+  - make --version
 
   # clang
   - ln -sf `which clang-5.0` $HOME/.local/bin/clang

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,8 @@ addons:
       - clang-format-5.0
       # python
       - python3
+      - python3-pip
+      - pylint3
 
 before_script:
   # create directory that will be on the PATH
@@ -49,13 +51,12 @@ before_script:
   - export PATH=$HOME/bin/:$PATH
 
   # clang
-  - ln -sf `which clang-5.0` "$HOME/bin/clang"
-  - ln -sf `which clang-format-5.0` "$HOME/bin/clang-format"
+  - ln -sf `which clang-5.0` $HOME/bin/clang
+  - ln -sf `which clang-format-5.0` $HOME/bin/clang-format
   - clang-format --version
 
   # Install pylint for python3
-  - sudo apt-get -y install python3-pip
-  - sudo pip3 install pylint
+  - ln -sf `which pylint3` $HOME/pylint
   - pylint --version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,6 @@ branches:
     - master
 
 addons:
-  apt:
     sources:
       - ubuntu-toolchain-r-test
       - llvm-toolchain-trusty-5.0
@@ -32,6 +31,7 @@ addons:
       # trusty repos
       - python3
       - python3-pip
+      - libc6-i386
 
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,28 +27,28 @@ addons:
 
 before_script:
   # create directory that will be on the PATH
-  - mkdir -p $HOME/bin
-  - export PATH=$HOME/bin/:$PATH
+  - mkdir -p $HOME/.local/bin
+  - export PATH=$HOME/.local/bin/:$PATH
 
   # install GCC ARM from GNU ARM Embedded Toolchain PPA and GCC 6
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get -qq update
   - sudo apt-get -y install gcc-arm-embedded
-  - ln -sf `which gcc-6` $HOME/bin/gcc
+  - ln -sf `which gcc-6` $HOME/.local/bin/gcc
 
   # build GNU Make 4.1 from source
   - wget http://ftp.gnu.org/gnu/make/make-4.1.tar.gz
   - tar xvf make-4.1.tar.gz
   - cd make-4.1
-  - ./configure --prefix=$HOME
+  - ./configure --prefix=$HOME/.local
   - make
   - make install
   - cd ..
   - rm -rf make-4.1
 
   # clang
-  - ln -sf `which clang-5.0` $HOME/bin/clang
-  - ln -sf `which clang-format-5.0` $HOME/bin/clang-format
+  - ln -sf `which clang-5.0` $HOME/.local/bin/clang
+  - ln -sf `which clang-format-5.0` $HOME/.local/bin/clang-format
   - clang-format --version
 
   # Install pylint for python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,9 @@
-sudo: false
-dist: "trusty"
+# Use full virtualisation to allow adding kernel modules
+sudo: true
+
+# Use trusty
+#   https://docs.travis-ci.com/user/trusty-ci-environment/
+dist: trusty
 
 notifications:
   email: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+dist: "trusty"
+
 notifications:
   email: false
 
@@ -22,8 +24,9 @@ addons:
       # llvm-toolchain-trusty-5.0
       - clang-5.0
       - clang-format-5.0
-      # python
+      # trusty repos
       - python3
+      - python3-pip
 
 before_script:
   # create directory that will be on the PATH
@@ -52,7 +55,7 @@ before_script:
   - clang-format --version
 
   # Install pylint for python3
-  - pip3 install -U pylint
+  - pip3 install --user pylint
   - pylint --version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,18 +24,17 @@ addons:
       - clang-format-5.0
       # python
       - python3
-      - python3-pip
-      - pylint3
 
 before_script:
   # create directory that will be on the PATH
   - mkdir -p $HOME/bin
+  - export PATH=$HOME/bin/:$PATH
 
   # install GCC ARM from GNU ARM Embedded Toolchain PPA and GCC 6
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get -qq update
   - sudo apt-get -y install gcc-arm-embedded
-  - sudo update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-6 90
+  - ln -sf `which gcc-6` $HOME/bin/gcc
 
   # build GNU Make 4.1 from source
   - wget http://ftp.gnu.org/gnu/make/make-4.1.tar.gz
@@ -47,16 +46,13 @@ before_script:
   - cd ..
   - rm -rf make-4.1
 
-  # add Make to path
-  - export PATH=$HOME/bin/:$PATH
-
   # clang
   - ln -sf `which clang-5.0` $HOME/bin/clang
   - ln -sf `which clang-format-5.0` $HOME/bin/clang-format
   - clang-format --version
 
   # Install pylint for python3
-  - ln -sf `which pylint3` $HOME/pylint
+  - pip3 install -U pylint
   - pylint --version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,12 +49,8 @@ before_script:
   - export PATH=$HOME/bin/:$PATH
 
   # clang
-  #- wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-  #- echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
-  #- sudo apt-get -qq update
-  #- sudo apt-get install -y clang-5.0 clang-format-5.0
-  - sudo update-alternatives --install /usr/local/bin/clang-format clang-format `which clang-format-5.0` 10
-  - sudo update-alternatives --install /usr/local/bin/clang clang `which clang-5.0` 10
+  - ln -sf `which clang-5.0` "$HOME/bin/clang"
+  - ln -sf `which clang-format-5.0` "$HOME/bin/clang-format"
   - clang-format --version
 
   # Install pylint for python3

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,14 +14,16 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test
+      - llvm-toolchain-trusty-5.0
     packages:
+      # ubuntu-toolchain-r-test
       - gcc-6
       - g++-6
+      # llvm-toolchain-trusty-5.0
+      - clang-5.0
+      - clang-format-5.0
+      # python
       - python3
-
-env:
-  # add target platforms to build matrix
-  # lint is a target so we don't need to lint multiple times
 
 before_script:
   # install GCC ARM from GNU ARM Embedded Toolchain PPA and GCC 6
@@ -44,10 +46,10 @@ before_script:
   - export PATH=/usr/local/bin/:$PATH
 
   # clang
-  - wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
-  - echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
-  - sudo apt-get -qq update
-  - sudo apt-get install -y clang-5.0 clang-format-5.0
+  #- wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+  #- echo "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-5.0 main" | sudo tee -a /etc/apt/sources.list
+  #- sudo apt-get -qq update
+  #- sudo apt-get install -y clang-5.0 clang-format-5.0
   - sudo update-alternatives --install /usr/local/bin/clang-format clang-format `which clang-format-5.0` 10
   - sudo update-alternatives --install /usr/local/bin/clang clang `which clang-5.0` 10
   - clang-format --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,7 +36,7 @@ addons:
 
 cache:
   directories:
-    - ${HOME}/gcc-arm-none-eabi-6-2017-q1-update
+    - ${HOME}/gcc-arm-none-eabi-6-2017-q2-update
 
 before_script:
   # create directory that will be on the PATH
@@ -46,9 +46,9 @@ before_script:
   - mkdir -p ${HOME}/source
 
   # install GCC ARM from GNU ARM Embedded Toolchain
-  - export GCC_DIR=${HOME}/gcc-arm-none-eabi-6-2017-q1-update
-  - export GCC_ARCHIVE=${HOME}/source/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2
-  - export GCC_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/6_1-2017q1/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2?product=GNU%20ARM%20Embedded%20Toolchain,64-bit,,Linux,6-2017-q1-update
+  - export GCC_DIR=${HOME}/gcc-arm-none-eabi-6-2017-q2-update
+  - export GCC_ARCHIVE=${HOME}/source/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2
+  - export GCC_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/6-2017q2/gcc-arm-none-eabi-6-2017-q2-update-linux.tar.bz2?revision=2cc92fb5-3e0e-402d-9197-bdfc8224d8a5?product=GNU%20Arm%20Embedded%20Toolchain,64-bit,,Linux,6-2017-q2-update
   - if [ ! -e ${GCC_DIR}/bin/arm-none-eabi-gcc ]; then
       wget $GCC_URL -O $GCC_ARCHIVE;
       tar xfj $GCC_ARCHIVE -C ${HOME};

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,39 +33,43 @@ addons:
       - python3
       - python3-pip
 
+cache:
+  directories:
+    - ${HOME}/gcc-arm-none-eabi-6-2017-q1-update
+
 before_script:
   # create directory that will be on the PATH
-  - mkdir -p $HOME/.local/bin
-  - export PATH=$HOME/.local/bin:$PATH
+  - mkdir -p ${HOME}/.local/bin
+  - export PATH=${HOME}/.local/bin:${PATH}
 
-  - mkdir -p $HOME/source
+  - mkdir -p ${HOME}/source
 
   # install GCC ARM from GNU ARM Embedded Toolchain
-  - export GCC_DIR=$HOME/gcc-arm-none-eabi-6-2017-q1-update
-  - export GCC_ARCHIVE=$HOME/source/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2
+  - export GCC_DIR=${HOME}/gcc-arm-none-eabi-6-2017-q1-update
+  - export GCC_ARCHIVE=${HOME}/source/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2
   - export GCC_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/6_1-2017q1/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2?product=GNU%20ARM%20Embedded%20Toolchain,64-bit,,Linux,6-2017-q1-update
-  - if [ ! -e $GCC_DIR/bin/arm-none-eabi-gcc ]; then
+  - if [ ! -e ${GCC_DIR}/bin/arm-none-eabi-gcc ]; then
       wget $GCC_URL -O $GCC_ARCHIVE;
-      tar xfj $GCC_ARCHIVE -C $HOME;
+      tar xfj $GCC_ARCHIVE -C ${HOME};
     fi
-  - export PATH=$PATH:$GCC_DIR/bin
+  - export PATH=${PATH}:${GCC_DIR}/bin
 
-  - ln -sf `which gcc-6` $HOME/.local/bin/gcc
+  - ln -sf `which gcc-6` ${HOME}/.local/bin/gcc
 
   # build GNU Make 4.1 from source
   # TODO: cache this block as well
   - wget http://ftp.gnu.org/gnu/make/make-4.1.tar.gz
   - tar xvf make-4.1.tar.gz
   - cd make-4.1
-  - ./configure --prefix=$HOME/.local
+  - ./configure --prefix=${HOME}/.local
   - make
   - make install
   - cd ..
   - rm -rf make-4.1
 
   # clang
-  - ln -sf `which clang-5.0` $HOME/.local/bin/clang
-  - ln -sf `which clang-format-5.0` $HOME/.local/bin/clang-format
+  - ln -sf `which clang-5.0` ${HOME}/.local/bin/clang
+  - ln -sf `which clang-format-5.0` ${HOME}/.local/bin/clang-format
 
   # Install pylint for python3
   - pip3 install --user pylint

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,11 +22,6 @@ addons:
 env:
   # add target platforms to build matrix
   # lint is a target so we don't need to lint multiple times
-  - TARGET='build_all PLATFORM=x86'
-  - TARGET='build_all PLATFORM=stm32f0xx'
-  - TARGET='test_all PLATFORM=x86'
-  - TARGET=lint
-  - TARGET=test_format
 
 before_script:
   # install GCC ARM from GNU ARM Embedded Toolchain PPA and GCC 6
@@ -63,4 +58,8 @@ before_script:
   - pylint --version
 
 script:
-  - make $TARGET
+  - make build_all PLATFORM=x86
+  - make build_all PLATFORM=stm32f0xx
+  - make test_all PLATFORM=x86
+  - make lint
+  - make test_format

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 dist: "trusty"
 
 notifications:
@@ -31,15 +32,24 @@ addons:
 before_script:
   # create directory that will be on the PATH
   - mkdir -p $HOME/.local/bin
-  - export PATH=$HOME/.local/bin/:$PATH
+  - export PATH=$HOME/.local/bin:$PATH
 
-  # install GCC ARM from GNU ARM Embedded Toolchain PPA and GCC 6
-  - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
-  - sudo apt-get -qq update
-  - sudo apt-get -y install gcc-arm-embedded
+  - mkdir -p $HOME/source
+
+  # install GCC ARM from GNU ARM Embedded Toolchain
+  - export GCC_DIR=$HOME/gcc-arm-none-eabi-6-2017-q1-update
+  - export GCC_ARCHIVE=$HOME/source/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2
+  - export GCC_URL=https://developer.arm.com/-/media/Files/downloads/gnu-rm/6_1-2017q1/gcc-arm-none-eabi-6-2017-q1-update-linux.tar.bz2?product=GNU%20ARM%20Embedded%20Toolchain,64-bit,,Linux,6-2017-q1-update
+  - if [ ! -e $GCC_DIR/bin/arm-none-eabi-gcc ]; then
+      wget $GCC_URL -O $GCC_ARCHIVE;
+      tar xfj $GCC_ARCHIVE -C $HOME;
+    fi
+  - export PATH=$PATH:$GCC_DIR/bin
+
   - ln -sf `which gcc-6` $HOME/.local/bin/gcc
 
   # build GNU Make 4.1 from source
+  # TODO: cache this block as well
   - wget http://ftp.gnu.org/gnu/make/make-4.1.tar.gz
   - tar xvf make-4.1.tar.gz
   - cd make-4.1
@@ -48,15 +58,26 @@ before_script:
   - make install
   - cd ..
   - rm -rf make-4.1
-  - make --version
 
   # clang
   - ln -sf `which clang-5.0` $HOME/.local/bin/clang
   - ln -sf `which clang-format-5.0` $HOME/.local/bin/clang-format
-  - clang-format --version
 
   # Install pylint for python3
   - pip3 install --user pylint
+
+  - hash -r
+  # print versions of everything
+  - arm-none-eabi-gcc --version
+  - arm-none-eabi-objcopy --version
+  - arm-none-eabi-objdump --version
+  - arm-none-eabi-size --version
+  - arm-none-eabi-gcc-ar --version
+  - arm-none-eabi-gdb --version
+  - gcc --version
+  - make --version
+  - clang --version
+  - clang-format --version
   - pylint --version
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ branches:
     - master
 
 addons:
+  apt:
     sources:
       - ubuntu-toolchain-r-test
       - llvm-toolchain-trusty-5.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,7 +74,9 @@ before_script:
   # Install pylint for python3
   - pip3 install --user pylint
 
+  # force ${PATH} to update
   - hash -r
+
   # print versions of everything
   - arm-none-eabi-gcc --version
   - arm-none-eabi-objcopy --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ addons:
       - python3
 
 before_script:
+  # create directory that will be on the PATH
+  - mkdir -p $HOME/bin
+
   # install GCC ARM from GNU ARM Embedded Toolchain PPA and GCC 6
   - sudo add-apt-repository ppa:team-gcc-arm-embedded/ppa -y
   - sudo apt-get -qq update
@@ -36,14 +39,14 @@ before_script:
   - wget http://ftp.gnu.org/gnu/make/make-4.1.tar.gz
   - tar xvf make-4.1.tar.gz
   - cd make-4.1
-  - ./configure
+  - ./configure --prefix=$HOME
   - make
-  - sudo make install
+  - make install
   - cd ..
   - rm -rf make-4.1
 
   # add Make to path
-  - export PATH=/usr/local/bin/:$PATH
+  - export PATH=$HOME/bin/:$PATH
 
   # clang
   #- wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://travis-ci.org/uw-midsun/firmware.svg?branch=master)](https://travis-ci.org/uw-midsun/firmware)
 
-Ignore this branch for now, I'm just testing some stuff with Travis.
+Ignore this branch for now, I'm just testing some more stuff with Travis.
 
 This repository contains all the latest firmware for the [University of Waterloo](https://uwaterloo.ca/)'s [Midnight Sun Solar Rayce Car](http://www.uwmidsun.com/) team.
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 [![Build Status](https://travis-ci.org/uw-midsun/firmware.svg?branch=master)](https://travis-ci.org/uw-midsun/firmware)
 
-Ignore this branch for now, I'm just testing some more stuff with Travis.
-
 This repository contains all the latest firmware for the [University of Waterloo](https://uwaterloo.ca/)'s [Midnight Sun Solar Rayce Car](http://www.uwmidsun.com/) team.
 
 ## Getting Started

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![Build Status](https://travis-ci.org/uw-midsun/firmware.svg?branch=master)](https://travis-ci.org/uw-midsun/firmware)
 
+Ignore this branch for now, I'm just testing some stuff with Travis.
+
 This repository contains all the latest firmware for the [University of Waterloo](https://uwaterloo.ca/)'s [Midnight Sun Solar Rayce Car](http://www.uwmidsun.com/) team.
 
 ## Getting Started


### PR DESCRIPTION
* Pin `gcc-arm-none-eabi-6-2017-q2-update`
* Speed up builds by caching
* Speed up builds by removing parallel jobs
  