### PR TITLE
ELEC-105: Chaos Power Path implementation

### DIFF
--- a/projects/chaos/inc/chaos_events.h
+++ b/projects/chaos/inc/chaos_events.h
@@ -1,0 +1,19 @@
+#pragma once
+
+// High priority messages in the event queue
+typedef enum {
+  NUM_CHAOS_EVENTS_CRITICAL = 0,
+} ChaosEventCritical;
+
+// CAN messages in the event queue
+typedef enum {
+  CHAOS_EVENT_CAN_UV_OV = NUM_CHAOS_EVENTS_CRITICAL + 1,
+  NUM_CHAOS_EVENTS_CAN,
+} ChaosEventCAN;
+
+// State transition messages in the event queue
+typedef enum {
+  NUM_CHAOS_EVENTS_FSM = NUM_CHAOS_EVENTS_CAN + 1,
+} ChaosEventFSM;
+
+#define NUM_CHAOS_EVENTS NUM_CHAOS_EVENTS_FSM

--- a/projects/chaos/inc/power_path.h
+++ b/projects/chaos/inc/power_path.h
@@ -1,0 +1,65 @@
+#pragma once
+// Chaos Power Path monitoring module.
+// Requires gpio, gpio interrupts, adcs, soft timers and interrupts to be initialized.
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "adc.h"
+#include "gpio.h"
+#include "soft_timer.h"
+#include "status.h"
+
+// Conversion callbacks for ADCs.
+typedef uint16_t (*power_path_conversion_callback)(uint16_t value);
+
+typedef enum {
+  POWER_PATH_SOURCE_ID_DCDC = 0,
+  POWER_PATH_SOURCE_ID_AUX_BAT,
+  NUM_POWER_PATH_SOURCE_ID,
+} PowerPathSourceID;
+
+// For storing voltage and current values.
+typedef struct PowerPathVCReadings {
+  uint16_t voltage;
+  uint16_t current;
+} PowerPathVCReadings;
+
+// For storing the Power Path Source (eg AUX Battery vs DCDCs).
+typedef struct PowerPathSource {
+  const GPIOAddress uv_ov_pin;
+  const GPIOAddress voltage_pin;
+  const GPIOAddress current_pin;
+  volatile PowerPathVCReadings readings;
+  power_path_conversion_callback current_convert;
+  power_path_conversion_callback voltage_convert;
+  uint32_t period_us;
+  SoftTimerID timer_id;
+  bool monitoring_active;
+} PowerPathSource;
+
+// For storing the power path configuration.
+typedef struct PowerPathCfg {
+  const GPIOAddress enable_pin;
+  const GPIOAddress shutdown_pin;
+  PowerPathSource aux_bat;
+  PowerPathSource dcdc;
+} PowerPathCfg;
+
+// Configures the GPIO pins for the power path.
+StatusCode power_path_init(PowerPathCfg *pp);
+
+// Enables the power path.
+StatusCode power_path_enable(const PowerPathCfg *pp);
+
+// Disables the power path, also disables monitoring on both sources.
+StatusCode power_path_disable(PowerPathCfg *pp);
+
+// Starts monitoring the specified power source periodically.
+StatusCode power_path_source_monitor_enable(PowerPathSource *source, uint32_t period_us);
+
+// Stops monitoring the specified power source periodically.
+StatusCode power_path_source_monitor_disable(PowerPathSource *source);
+
+// Reads the latest voltage and current from the specified power source.
+StatusCode power_path_read_source(const PowerPathSource *source, PowerPathVCReadings *values);

--- a/projects/chaos/inc/power_path.h
+++ b/projects/chaos/inc/power_path.h
@@ -11,12 +11,12 @@
 #include "status.h"
 
 // Conversion callbacks for ADCs.
-typedef uint16_t (*power_path_conversion_callback)(uint16_t value);
+typedef uint16_t (*PowerPathConversionCallback)(uint16_t value);
 
 typedef enum {
   POWER_PATH_SOURCE_ID_DCDC = 0,
   POWER_PATH_SOURCE_ID_AUX_BAT,
-  NUM_POWER_PATH_SOURCE_ID,
+  NUM_POWER_PATH_SOURCE_IDS,
 } PowerPathSourceID;
 
 // For storing voltage and current values.
@@ -32,8 +32,8 @@ typedef struct PowerPathSource {
   const GPIOAddress voltage_pin;
   const GPIOAddress current_pin;
   volatile PowerPathVCReadings readings;
-  power_path_conversion_callback current_convert;
-  power_path_conversion_callback voltage_convert;
+  PowerPathConversionCallback current_convert;
+  PowerPathConversionCallback voltage_convert;
   uint32_t period_us;
   SoftTimerID timer_id;
   bool monitoring_active;

--- a/projects/chaos/inc/power_path.h
+++ b/projects/chaos/inc/power_path.h
@@ -27,6 +27,7 @@ typedef struct PowerPathVCReadings {
 
 // For storing the Power Path Source (eg AUX Battery vs DCDCs).
 typedef struct PowerPathSource {
+  const PowerPathSourceID id;
   const GPIOAddress uv_ov_pin;
   const GPIOAddress voltage_pin;
   const GPIOAddress current_pin;

--- a/projects/chaos/inc/power_path.h
+++ b/projects/chaos/inc/power_path.h
@@ -10,8 +10,8 @@
 #include "soft_timer.h"
 #include "status.h"
 
-// Conversion callbacks for ADCs.
-typedef uint16_t (*PowerPathConversionCallback)(uint16_t value);
+// Conversion function signature for ADCs.
+typedef uint16_t (*PowerPathConversionFn)(uint16_t value);
 
 typedef enum {
   POWER_PATH_SOURCE_ID_DCDC = 0,
@@ -32,8 +32,8 @@ typedef struct PowerPathSource {
   const GPIOAddress voltage_pin;
   const GPIOAddress current_pin;
   volatile PowerPathVCReadings readings;
-  PowerPathConversionCallback current_convert;
-  PowerPathConversionCallback voltage_convert;
+  PowerPathConversionFn current_convert_fn;
+  PowerPathConversionFn voltage_convert_fn;
   uint32_t period_us;
   SoftTimerID timer_id;
   bool monitoring_active;
@@ -49,12 +49,6 @@ typedef struct PowerPathCfg {
 
 // Configures the GPIO pins for the power path.
 StatusCode power_path_init(PowerPathCfg *pp);
-
-// Enables the power path.
-StatusCode power_path_enable(const PowerPathCfg *pp);
-
-// Disables the power path, also disables monitoring on both sources.
-StatusCode power_path_disable(PowerPathCfg *pp);
 
 // Starts monitoring the specified power source periodically.
 StatusCode power_path_source_monitor_enable(PowerPathSource *source, uint32_t period_us);

--- a/projects/chaos/rules.mk
+++ b/projects/chaos/rules.mk
@@ -7,3 +7,7 @@
 
 # Specify the device library you want to include
 $(T)_DEPS := ms-common
+
+ifeq (x86,$(PLATFORM))
+$(T)_EXCLUDE_TESTS := power_path
+endif

--- a/projects/chaos/src/power_path.c
+++ b/projects/chaos/src/power_path.c
@@ -1,0 +1,147 @@
+#include "power_path.h"
+
+#include <stdbool.h>
+#include <string.h>
+
+#include "adc.h"
+#include "chaos_events.h"
+#include "event_queue.h"
+#include "gpio.h"
+#include "gpio_it.h"
+#include "interrupt.h"
+#include "soft_timer.h"
+#include "status.h"
+
+// Evaluates if two GPIO addresses are equal.
+static bool prv_addr_eq(GPIOAddress addr1, GPIOAddress addr2) {
+  return ((addr1.port == addr2.port) && (addr1.pin == addr2.pin));
+}
+
+// Interrupt handler for over and under voltage warnings.
+static void prv_voltage_warning(const GPIOAddress *addr, void *context) {
+  PowerPathCfg *pp = context;
+  if (prv_addr_eq(*addr, pp->dcdc.uv_ov_pin) && pp->dcdc.monitoring_active) {
+    event_raise(CHAOS_EVENT_CAN_UV_OV, POWER_PATH_SOURCE_ID_DCDC);
+  } else if (prv_addr_eq(*addr, pp->aux_bat.uv_ov_pin) && pp->aux_bat.monitoring_active) {
+    event_raise(CHAOS_EVENT_CAN_UV_OV, POWER_PATH_SOURCE_ID_AUX_BAT);
+  }
+}
+
+static void prv_adc_read(SoftTimerID timer_id, void *context) {
+  PowerPathSource *pps = context;
+  if (pps->timer_id != timer_id || !pps->monitoring_active) {
+    // Guard against accidentally starting multiple timers to monitor the same source concurrently.
+    return;
+  }
+
+  uint16_t value = 0;
+  ADCChannel chan = NUM_ADC_CHANNELS;
+  // Read and convert the current values.
+  adc_get_channel(pps->current_pin, &chan);
+  adc_read_raw(chan, &value);
+  pps->readings.current = pps->current_convert(value);
+
+  // Read and convert the voltage values.
+  adc_get_channel(pps->voltage_pin, &chan);
+  adc_read_raw(chan, &value);
+  pps->readings.voltage = pps->voltage_convert(value);
+
+  // Start the next timer.
+  soft_timer_start(pps->period_us, prv_adc_read, pps, &pps->timer_id);
+}
+
+StatusCode power_path_init(PowerPathCfg *pp) {
+  GPIOSettings settings = {
+    .direction = GPIO_DIR_OUT,
+    .state = GPIO_STATE_HIGH,
+    .resistor = GPIO_RES_NONE,
+    .alt_function = GPIO_ALTFN_NONE,
+  };
+
+  status_ok_or_return(gpio_init_pin(&pp->enable_pin, &settings));
+  status_ok_or_return(gpio_init_pin(&pp->shutdown_pin, &settings));
+
+  // Configure the Interrupt Pins
+  settings.direction = GPIO_DIR_IN;
+  settings.state = GPIO_STATE_LOW;
+  status_ok_or_return(gpio_init_pin(&pp->aux_bat.uv_ov_pin, &settings));
+  status_ok_or_return(gpio_init_pin(&pp->dcdc.uv_ov_pin, &settings));
+
+  // Register interrupts to the same function.
+  const InterruptSettings it_settings = {
+    .type = INTERRUPT_TYPE_INTERRUPT,
+    .priority = INTERRUPT_PRIORITY_NORMAL,
+  };
+  status_ok_or_return(gpio_it_register_interrupt(&pp->aux_bat.uv_ov_pin, &it_settings,
+                                                 INTERRUPT_EDGE_RISING, prv_voltage_warning, pp));
+  status_ok_or_return(gpio_it_register_interrupt(&pp->dcdc.uv_ov_pin, &it_settings,
+                                                 INTERRUPT_EDGE_RISING, prv_voltage_warning, pp));
+
+  // Configure the ADC Pins
+  settings.alt_function = GPIO_ALTFN_ANALOG;
+  status_ok_or_return(gpio_init_pin(&pp->aux_bat.voltage_pin, &settings));
+  status_ok_or_return(gpio_init_pin(&pp->aux_bat.current_pin, &settings));
+  status_ok_or_return(gpio_init_pin(&pp->dcdc.voltage_pin, &settings));
+  return gpio_init_pin(&pp->dcdc.current_pin, &settings);
+}
+
+StatusCode power_path_enable(const PowerPathCfg *pp) {
+  status_ok_or_return(gpio_set_state(&pp->shutdown_pin, GPIO_STATE_HIGH));
+  return gpio_set_state(&pp->enable_pin, GPIO_STATE_HIGH);
+}
+
+StatusCode power_path_disable(PowerPathCfg *pp) {
+  // Stop interrupts from firing first to avoid false readings after shutdown.
+  status_ok_or_return(power_path_source_monitor_disable(&pp->aux_bat));
+  status_ok_or_return(power_path_source_monitor_disable(&pp->dcdc));
+  status_ok_or_return(gpio_set_state(&pp->shutdown_pin, GPIO_STATE_LOW));
+  return gpio_set_state(&pp->enable_pin, GPIO_STATE_LOW);
+}
+
+StatusCode power_path_source_monitor_enable(PowerPathSource *source, uint32_t period_us) {
+  // Update the period.
+  source->period_us = period_us;
+
+  // Avoid doing anything else if monitoring
+  if (source->monitoring_active) {
+    return STATUS_CODE_OK;
+  }
+
+  // Set up adc current/voltage monitoring
+  ADCChannel chan = NUM_ADC_CHANNELS;
+  adc_get_channel(source->current_pin, &chan);
+  status_ok_or_return(adc_set_channel(chan, true));
+  adc_get_channel(source->voltage_pin, &chan);
+  status_ok_or_return(adc_set_channel(chan, true));
+
+  source->monitoring_active = true;
+
+  return soft_timer_start(source->period_us, prv_adc_read, source, &source->timer_id);
+}
+
+StatusCode power_path_source_monitor_disable(PowerPathSource *source) {
+  if (!source->monitoring_active) {
+    return STATUS_CODE_OK;
+  }
+
+  source->monitoring_active = false;
+  // Ignore this return since we don't care if the timer is already disabled.
+  soft_timer_cancel(source->timer_id);
+
+  // Disable the ADCs
+  ADCChannel chan = NUM_ADC_CHANNELS;
+  adc_get_channel(source->current_pin, &chan);
+  status_ok_or_return(adc_set_channel(chan, false));
+  adc_get_channel(source->voltage_pin, &chan);
+  return adc_set_channel(chan, false);
+}
+
+StatusCode power_path_read_source(const PowerPathSource *source, PowerPathVCReadings *values) {
+  if (!source->monitoring_active) {
+    // Fail if not actively monitoring as the data is not up to date.
+    return status_code(STATUS_CODE_UNINITIALIZED);
+  }
+
+  *values = source->readings;
+  return STATUS_CODE_OK;
+}

--- a/projects/chaos/test/test_power_path.c
+++ b/projects/chaos/test/test_power_path.c
@@ -43,6 +43,7 @@ static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
                               .shutdown_pin = { .port = 0, .pin = 1 },
                               .aux_bat =
                                   {
+                                      .id = POWER_PATH_SOURCE_ID_AUX_BAT,
                                       .uv_ov_pin = { .port = 0, .pin = 2 },
                                       .voltage_pin = { .port = 0, .pin = 3 },
                                       .current_pin = { .port = 0, .pin = 4 },
@@ -58,6 +59,7 @@ static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
                                       .monitoring_active = false,
                                   },
                               .dcdc = {
+                                  .id = POWER_PATH_SOURCE_ID_DCDC,
                                   .uv_ov_pin = { .port = 0, .pin = 5 },
                                   .voltage_pin = { .port = 0, .pin = 6 },
                                   .current_pin = { .port = 0, .pin = 7 },

--- a/projects/chaos/test/test_power_path.c
+++ b/projects/chaos/test/test_power_path.c
@@ -46,8 +46,8 @@ static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
                                            .voltage_pin = { .port = 0, .pin = 3 },
                                            .current_pin = { .port = 0, .pin = 4 },
                                            .readings = { .voltage = 0, .current = 0 },
-                                           .current_convert = prv_aux_current_convert,
-                                           .voltage_convert = prv_aux_voltage_convert,
+                                           .current_convert_fn = prv_aux_current_convert,
+                                           .voltage_convert_fn = prv_aux_voltage_convert,
                                            .period_us = 0,
                                            .timer_id = SOFT_TIMER_INVALID_TIMER,
                                            .monitoring_active = false },
@@ -56,8 +56,8 @@ static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
                                         .voltage_pin = { .port = 0, .pin = 6 },
                                         .current_pin = { .port = 0, .pin = 7 },
                                         .readings = { .voltage = 0, .current = 0 },
-                                        .current_convert = prv_dcdc_current_convert,
-                                        .voltage_convert = prv_dcdc_voltage_convert,
+                                        .current_convert_fn = prv_dcdc_current_convert,
+                                        .voltage_convert_fn = prv_dcdc_voltage_convert,
                                         .period_us = 0,
                                         .timer_id = SOFT_TIMER_INVALID_TIMER,
                                         .monitoring_active = false } };
@@ -75,8 +75,6 @@ void setup_test(void) {
 void teardown_test(void) {}
 
 void test_power_path_uv_ov(void) {
-  TEST_ASSERT_OK(power_path_enable(&s_ppc));
-
   TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.aux_bat, TEST_POWER_PATH_ADC_PERIOD_US));
   TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.dcdc, TEST_POWER_PATH_ADC_PERIOD_US));
 
@@ -93,12 +91,11 @@ void test_power_path_uv_ov(void) {
   TEST_ASSERT_EQUAL(CHAOS_EVENT_CAN_UV_OV, e.id);
   TEST_ASSERT_EQUAL(POWER_PATH_SOURCE_ID_DCDC, e.data);
 
-  TEST_ASSERT_OK(power_path_disable(&s_ppc));
+  TEST_ASSERT_OK(power_path_source_monitor_disable(&s_ppc.aux_bat));
+  TEST_ASSERT_OK(power_path_source_monitor_disable(&s_ppc.dcdc));
 }
 
 void test_power_path_adcs(void) {
-  TEST_ASSERT_OK(power_path_enable(&s_ppc));
-
   TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.aux_bat, TEST_POWER_PATH_ADC_PERIOD_US));
   TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.dcdc, TEST_POWER_PATH_ADC_PERIOD_US));
 
@@ -117,6 +114,4 @@ void test_power_path_adcs(void) {
 
   TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, power_path_read_source(&s_ppc.aux_bat, &readings));
   TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, power_path_read_source(&s_ppc.dcdc, &readings));
-
-  TEST_ASSERT_OK(power_path_disable(&s_ppc));
 }

--- a/projects/chaos/test/test_power_path.c
+++ b/projects/chaos/test/test_power_path.c
@@ -41,39 +41,26 @@ static uint16_t prv_dcdc_voltage_convert(uint16_t value) {
 
 static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
                               .shutdown_pin = { .port = 0, .pin = 1 },
-                              .aux_bat =
-                                  {
-                                      .id = POWER_PATH_SOURCE_ID_AUX_BAT,
-                                      .uv_ov_pin = { .port = 0, .pin = 2 },
-                                      .voltage_pin = { .port = 0, .pin = 3 },
-                                      .current_pin = { .port = 0, .pin = 4 },
-                                      .readings =
-                                          {
-                                              .voltage = 0,
-                                              .current = 0,
-                                          },
-                                      .current_convert = prv_aux_current_convert,
-                                      .voltage_convert = prv_aux_voltage_convert,
-                                      .period_us = 0,
-                                      .timer_id = SOFT_TIMER_INVALID_TIMER,
-                                      .monitoring_active = false,
-                                  },
-                              .dcdc = {
-                                  .id = POWER_PATH_SOURCE_ID_DCDC,
-                                  .uv_ov_pin = { .port = 0, .pin = 5 },
-                                  .voltage_pin = { .port = 0, .pin = 6 },
-                                  .current_pin = { .port = 0, .pin = 7 },
-                                  .readings =
-                                      {
-                                          .voltage = 0,
-                                          .current = 0,
-                                      },
-                                  .current_convert = prv_dcdc_current_convert,
-                                  .voltage_convert = prv_dcdc_voltage_convert,
-                                  .period_us = 0,
-                                  .timer_id = SOFT_TIMER_INVALID_TIMER,
-                                  .monitoring_active = false,
-                              } };
+                              .aux_bat = { .id = POWER_PATH_SOURCE_ID_AUX_BAT,
+                                           .uv_ov_pin = { .port = 0, .pin = 2 },
+                                           .voltage_pin = { .port = 0, .pin = 3 },
+                                           .current_pin = { .port = 0, .pin = 4 },
+                                           .readings = { .voltage = 0, .current = 0 },
+                                           .current_convert = prv_aux_current_convert,
+                                           .voltage_convert = prv_aux_voltage_convert,
+                                           .period_us = 0,
+                                           .timer_id = SOFT_TIMER_INVALID_TIMER,
+                                           .monitoring_active = false },
+                              .dcdc = { .id = POWER_PATH_SOURCE_ID_DCDC,
+                                        .uv_ov_pin = { .port = 0, .pin = 5 },
+                                        .voltage_pin = { .port = 0, .pin = 6 },
+                                        .current_pin = { .port = 0, .pin = 7 },
+                                        .readings = { .voltage = 0, .current = 0 },
+                                        .current_convert = prv_dcdc_current_convert,
+                                        .voltage_convert = prv_dcdc_voltage_convert,
+                                        .period_us = 0,
+                                        .timer_id = SOFT_TIMER_INVALID_TIMER,
+                                        .monitoring_active = false } };
 
 void setup_test(void) {
   event_queue_init();

--- a/projects/chaos/test/test_power_path.c
+++ b/projects/chaos/test/test_power_path.c
@@ -1,0 +1,133 @@
+#include "power_path.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "adc.h"
+#include "chaos_events.h"
+#include "delay.h"
+#include "event_queue.h"
+#include "gpio.h"
+#include "gpio_it.h"
+#include "interrupt.h"
+#include "log.h"
+#include "soft_timer.h"
+#include "status.h"
+#include "test_helpers.h"
+#include "unity.h"
+
+#define TEST_POWER_PATH_ADC_PERIOD_US 1000
+
+#define TEST_POWER_PATH_AUX_CURRENT_VAL 1
+#define TEST_POWER_PATH_AUX_VOLTAGE_VAL 2
+#define TEST_POWER_PATH_DCDC_CURRENT_VAL 3
+#define TEST_POWER_PATH_DCDC_VOLTAGE_VAL 4
+
+static uint16_t prv_aux_current_convert(uint16_t value) {
+  return TEST_POWER_PATH_AUX_CURRENT_VAL;
+}
+
+static uint16_t prv_aux_voltage_convert(uint16_t value) {
+  return TEST_POWER_PATH_AUX_VOLTAGE_VAL;
+}
+
+static uint16_t prv_dcdc_current_convert(uint16_t value) {
+  return TEST_POWER_PATH_DCDC_CURRENT_VAL;
+}
+
+static uint16_t prv_dcdc_voltage_convert(uint16_t value) {
+  return TEST_POWER_PATH_DCDC_VOLTAGE_VAL;
+}
+
+static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
+                              .shutdown_pin = { .port = 0, .pin = 1 },
+                              .aux_bat =
+                                  {
+                                      .uv_ov_pin = { .port = 0, .pin = 2 },
+                                      .voltage_pin = { .port = 0, .pin = 3 },
+                                      .current_pin = { .port = 0, .pin = 4 },
+                                      .readings =
+                                          {
+                                              .voltage = 0,
+                                              .current = 0,
+                                          },
+                                      .current_convert = prv_aux_current_convert,
+                                      .voltage_convert = prv_aux_voltage_convert,
+                                      .period_us = 0,
+                                      .timer_id = SOFT_TIMER_INVALID_TIMER,
+                                      .monitoring_active = false,
+                                  },
+                              .dcdc = {
+                                  .uv_ov_pin = { .port = 0, .pin = 5 },
+                                  .voltage_pin = { .port = 0, .pin = 6 },
+                                  .current_pin = { .port = 0, .pin = 7 },
+                                  .readings =
+                                      {
+                                          .voltage = 0,
+                                          .current = 0,
+                                      },
+                                  .current_convert = prv_dcdc_current_convert,
+                                  .voltage_convert = prv_dcdc_voltage_convert,
+                                  .period_us = 0,
+                                  .timer_id = SOFT_TIMER_INVALID_TIMER,
+                                  .monitoring_active = false,
+                              } };
+
+void setup_test(void) {
+  event_queue_init();
+  gpio_init();
+  interrupt_init();
+  gpio_it_init();
+  soft_timer_init();
+  adc_init(ADC_MODE_SINGLE);
+  TEST_ASSERT_OK(power_path_init(&s_ppc));
+}
+
+void teardown_test(void) {}
+
+void test_power_path_uv_ov(void) {
+  TEST_ASSERT_OK(power_path_enable(&s_ppc));
+
+  TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.aux_bat, TEST_POWER_PATH_ADC_PERIOD_US));
+  TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.dcdc, TEST_POWER_PATH_ADC_PERIOD_US));
+
+  gpio_it_trigger_interrupt(&s_ppc.aux_bat.uv_ov_pin);
+  Event e = { 0, 0 };
+  while (event_process(&e) != STATUS_CODE_OK) {
+  }
+  TEST_ASSERT_EQUAL(CHAOS_EVENT_CAN_UV_OV, e.id);
+  TEST_ASSERT_EQUAL(POWER_PATH_SOURCE_ID_AUX_BAT, e.data);
+
+  gpio_it_trigger_interrupt(&s_ppc.dcdc.uv_ov_pin);
+  while (event_process(&e) != STATUS_CODE_OK) {
+  }
+  TEST_ASSERT_EQUAL(CHAOS_EVENT_CAN_UV_OV, e.id);
+  TEST_ASSERT_EQUAL(POWER_PATH_SOURCE_ID_DCDC, e.data);
+
+  TEST_ASSERT_OK(power_path_disable(&s_ppc));
+}
+
+void test_power_path_adcs(void) {
+  TEST_ASSERT_OK(power_path_enable(&s_ppc));
+
+  TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.aux_bat, TEST_POWER_PATH_ADC_PERIOD_US));
+  TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.dcdc, TEST_POWER_PATH_ADC_PERIOD_US));
+
+  delay_us(TEST_POWER_PATH_ADC_PERIOD_US + TEST_POWER_PATH_ADC_PERIOD_US / 10);
+
+  PowerPathVCReadings readings = { 0, 0 };
+  TEST_ASSERT_OK(power_path_read_source(&s_ppc.aux_bat, &readings));
+  TEST_ASSERT_EQUAL(TEST_POWER_PATH_AUX_CURRENT_VAL, readings.current);
+  TEST_ASSERT_EQUAL(TEST_POWER_PATH_AUX_VOLTAGE_VAL, readings.voltage);
+  TEST_ASSERT_OK(power_path_read_source(&s_ppc.dcdc, &readings));
+  TEST_ASSERT_EQUAL(TEST_POWER_PATH_DCDC_CURRENT_VAL, readings.current);
+  TEST_ASSERT_EQUAL(TEST_POWER_PATH_DCDC_VOLTAGE_VAL, readings.voltage);
+
+  TEST_ASSERT_OK(power_path_source_monitor_disable(&s_ppc.aux_bat));
+  TEST_ASSERT_OK(power_path_source_monitor_disable(&s_ppc.dcdc));
+
+  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, power_path_read_source(&s_ppc.aux_bat, &readings));
+  TEST_ASSERT_EQUAL(STATUS_CODE_UNINITIALIZED, power_path_read_source(&s_ppc.dcdc, &readings));
+
+  TEST_ASSERT_OK(power_path_disable(&s_ppc));
+}


### PR DESCRIPTION
This is an implementation of the "driver" for the power path IC. Essentially this boils down to two main purposes:

-  Monitor the UV and OV pin which signals when an over or under voltage occurs by raising an event. This event will be handled by a CAN FSM which will send the message to Telemetry/Driver Display.
- Read values using the ADCs periodically for current and voltage of both the Aux Battery and DCDCs. It is possible to request the latest data at any time. I will add a hook later to send a CAN message with this info to telemetry each time it updates.

I also exposed an API to disable monitoring to avoid errors when turning off the DCDCs.
  
Tested manually on STM32F0xx and passed. x86 test fails as the ADC driver is unimplemented.
  