### PR TITLE
ELEC-305: CAN Extended ID Support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -141,10 +141,10 @@ lint:
 format:
 	@echo "Formatting *.[ch] in $(PROJ_DIR), $(LIB_DIR)"
 	@echo "Excluding libraries: $(IGNORE_CLEANUP_LIBS)"
-	@$(FIND) | xargs -r clang-format -i
+	@$(FIND) | xargs -r clang-format -i -style=file
 
 # Tests that all files have been run through the format target mainly for CI usage
-test_format: format 
+test_format: format
 	@! git diff --name-only --diff-filter=ACMRT | xargs -n1 clang-format -style=file -output-replacements-xml | grep '<replacements' > /dev/null; if [ $$? -ne 0 ] ; then git --no-pager diff && exit 1 ; fi
 
 # Builds the project or library

--- a/libraries/ms-common/inc/can_hw.h
+++ b/libraries/ms-common/inc/can_hw.h
@@ -47,11 +47,11 @@ StatusCode can_hw_init(const CANHwSettings *settings);
 // Registers a callback for the given event
 StatusCode can_hw_register_callback(CANHwEvent event, CANHwEventHandlerCb callback, void *context);
 
-StatusCode can_hw_add_filter(uint16_t mask, uint16_t filter);
+StatusCode can_hw_add_filter(uint32_t mask, uint32_t filter, bool extended);
 
 CANHwBusStatus can_hw_bus_status(void);
 
-StatusCode can_hw_transmit(uint16_t id, const uint8_t *data, size_t len);
+StatusCode can_hw_transmit(uint32_t id, bool extended, const uint8_t *data, size_t len);
 
 // Must be called within the RX handler, returns whether a message was processed
-bool can_hw_receive(uint16_t *id, uint64_t *data, size_t *len);
+bool can_hw_receive(uint32_t *id, bool *extended, uint64_t *data, size_t *len);

--- a/libraries/ms-common/src/can.c
+++ b/libraries/ms-common/src/can.c
@@ -85,7 +85,7 @@ StatusCode can_add_filter(CANMessageID msg_id) {
   CANId mask = { 0 };
   mask.msg_id = ~mask.msg_id;
 
-  return can_hw_add_filter(can_id.raw, mask.raw);
+  return can_hw_add_filter(can_id.raw, mask.raw, false);
 }
 
 StatusCode can_register_rx_default_handler(CANRxHandlerCb handler, void *context) {
@@ -151,12 +151,17 @@ void prv_tx_handler(void *context) {
 // Each event will result in one message's processing.
 void prv_rx_handler(void *context) {
   CANStorage *can_storage = context;
-  CANId rx_id = { 0 };
+  uint32_t rx_id = 0;
   CANMessage rx_msg = { 0 };
   size_t counter = 0;
 
-  while (can_hw_receive(&rx_id.raw, &rx_msg.data, &rx_msg.dlc)) {
-    CAN_MSG_SET_RAW_ID(&rx_msg, rx_id.raw);
+  bool extended = false;
+  while (can_hw_receive(&rx_id, &extended, &rx_msg.data, &rx_msg.dlc)) {
+    if (extended) {
+      // We don't handle extended messages in the network layer
+      continue;
+    }
+    CAN_MSG_SET_RAW_ID(&rx_msg, rx_id);
 
     StatusCode result = can_fifo_push(&can_storage->rx_fifo, &rx_msg);
     // TODO(ELEC-251): add error handling for FSMs

--- a/libraries/ms-common/src/can_fsm.c
+++ b/libraries/ms-common/src/can_fsm.c
@@ -92,7 +92,7 @@ static void prv_handle_tx(FSM *fsm, const Event *e, void *context) {
   };
 
   // If added to mailbox, pop message from the TX queue
-  StatusCode ret = can_hw_transmit(msg_id.raw, tx_msg.data_u8, tx_msg.dlc);
+  StatusCode ret = can_hw_transmit(msg_id.raw, false, tx_msg.data_u8, tx_msg.dlc);
   if (ret == STATUS_CODE_OK) {
     can_fifo_pop(&can_storage->tx_fifo, NULL);
   }

--- a/libraries/ms-common/src/stm32f0xx/can_hw.c
+++ b/libraries/ms-common/src/stm32f0xx/can_hw.c
@@ -62,7 +62,7 @@ StatusCode can_hw_init(const CANHwSettings *settings) {
 
   // Allow all messages by default, but reset the filter count so it's overwritten on the first
   // filter
-  can_hw_add_filter(0, 0);
+  can_hw_add_filter(0, 0, false);
   s_num_filters = 0;
 
   return STATUS_CODE_OK;
@@ -81,24 +81,31 @@ StatusCode can_hw_register_callback(CANHwEvent event, CANHwEventHandlerCb callba
   return STATUS_CODE_OK;
 }
 
-StatusCode can_hw_add_filter(uint16_t mask, uint16_t filter) {
+StatusCode can_hw_add_filter(uint32_t mask, uint32_t filter, bool extended) {
   if (s_num_filters >= CAN_HW_NUM_FILTER_BANKS) {
     return status_msg(STATUS_CODE_RESOURCE_EXHAUSTED, "CAN HW: Ran out of filter banks.");
   }
 
-  // We currently use 32-bit filters. We could use 16-bit filters instead since we're only using
-  // standard 11-bit IDs.
+  // 32-bit Filter - Identifer Mask
+  // STID[10:3] | STID[2:0] EXID[17:13] | EXID[12:5] | EXID[4:0] [IDE] [RTR] 0
+  size_t offset = extended ? 3 : 21;
+  // We always set the IDE bit for the mask so we distinguish between standard and extended
+  // TODO: remove magic values?
+  uint32_t mask_val = (mask << offset) | (1 << 2);
+  uint32_t filter_val = (filter << offset) | ((uint32_t)extended << 2);
+
   CAN_FilterInitTypeDef filter_cfg = {
     .CAN_FilterNumber = s_num_filters,
     .CAN_FilterMode = CAN_FilterMode_IdMask,
     .CAN_FilterScale = CAN_FilterScale_32bit,
-    .CAN_FilterIdHigh = filter << 5,
-    .CAN_FilterIdLow = 0x0000,
-    .CAN_FilterMaskIdHigh = mask << 5,
-    .CAN_FilterMaskIdLow = 0x0000,
+    .CAN_FilterIdHigh = filter_val >> 16,
+    .CAN_FilterIdLow = filter_val,
+    .CAN_FilterMaskIdHigh = mask_val >> 16,
+    .CAN_FilterMaskIdLow = mask_val,
     .CAN_FilterFIFOAssignment = (s_num_filters % 2),
     .CAN_FilterActivation = ENABLE,
   };
+
   CAN_FilterInit(&filter_cfg);
 
   s_num_filters++;
@@ -116,10 +123,12 @@ CANHwBusStatus can_hw_bus_status(void) {
   return CAN_HW_BUS_STATUS_OK;
 }
 
-StatusCode can_hw_transmit(uint16_t id, const uint8_t *data, size_t len) {
+StatusCode can_hw_transmit(uint32_t id, bool extended, const uint8_t *data, size_t len) {
+  // We can set both since the used ID is determined by tx_msg.IDE
   CanTxMsg tx_msg = {
     .StdId = id,        //
-    .IDE = CAN_ID_STD,  //
+    .ExtId = id, //
+    .IDE = extended ? CAN_Id_Standard : CAN_Id_Extended,  //
     .DLC = len,         //
   };
 
@@ -133,7 +142,7 @@ StatusCode can_hw_transmit(uint16_t id, const uint8_t *data, size_t len) {
   return STATUS_CODE_OK;
 }
 
-bool can_hw_receive(uint16_t *id, uint64_t *data, size_t *len) {
+bool can_hw_receive(uint32_t *id, bool *extended, uint64_t *data, size_t *len) {
   // 0: No messages available
   // 1: FIFO0 has received a message
   // 2: FIFO1 has received a message
@@ -150,7 +159,8 @@ bool can_hw_receive(uint16_t *id, uint64_t *data, size_t *len) {
   CanRxMsg rx_msg = { 0 };
   CAN_Receive(CAN_HW_BASE, fifo, &rx_msg);
 
-  *id = rx_msg.StdId;
+  *extended = (rx_msg.IDE == CAN_Id_Extended);
+  *id = *extended ? rx_msg.ExtId : rx_msg.StdId;
   *len = rx_msg.DLC;
   memcpy(data, rx_msg.Data, sizeof(*rx_msg.Data) * rx_msg.DLC);
 

--- a/libraries/ms-common/src/stm32f0xx/can_hw.c
+++ b/libraries/ms-common/src/stm32f0xx/can_hw.c
@@ -126,10 +126,10 @@ CANHwBusStatus can_hw_bus_status(void) {
 StatusCode can_hw_transmit(uint32_t id, bool extended, const uint8_t *data, size_t len) {
   // We can set both since the used ID is determined by tx_msg.IDE
   CanTxMsg tx_msg = {
-    .StdId = id,        //
-    .ExtId = id, //
+    .StdId = id,                                          //
+    .ExtId = id,                                          //
     .IDE = extended ? CAN_Id_Standard : CAN_Id_Extended,  //
-    .DLC = len,         //
+    .DLC = len,                                           //
   };
 
   memcpy(tx_msg.Data, data, len);

--- a/libraries/ms-common/src/stm32f0xx/can_hw.c
+++ b/libraries/ms-common/src/stm32f0xx/can_hw.c
@@ -90,7 +90,6 @@ StatusCode can_hw_add_filter(uint32_t mask, uint32_t filter, bool extended) {
   // STID[10:3] | STID[2:0] EXID[17:13] | EXID[12:5] | EXID[4:0] [IDE] [RTR] 0
   size_t offset = extended ? 3 : 21;
   // We always set the IDE bit for the mask so we distinguish between standard and extended
-  // TODO: remove magic values?
   uint32_t mask_val = (mask << offset) | (1 << 2);
   uint32_t filter_val = (filter << offset) | ((uint32_t)extended << 2);
 

--- a/libraries/ms-common/src/x86/can_hw.c
+++ b/libraries/ms-common/src/x86/can_hw.c
@@ -213,8 +213,10 @@ StatusCode can_hw_add_filter(uint32_t mask, uint32_t filter, bool extended) {
     return status_msg(STATUS_CODE_RESOURCE_EXHAUSTED, "CAN HW: Ran out of filters.");
   }
 
-  s_socket_data.filters[s_socket_data.num_filters].can_id = filter & CAN_SFF_MASK;
-  s_socket_data.filters[s_socket_data.num_filters].can_mask = mask & CAN_SFF_MASK;
+  uint32_t reg_mask = extended ? CAN_EFF_MASK : CAN_SFF_MASK;
+  uint32_t ide = extended ? CAN_EFF_FLAG : 0;
+  s_socket_data.filters[s_socket_data.num_filters].can_id = (filter & reg_mask) | ide;
+  s_socket_data.filters[s_socket_data.num_filters].can_mask = (mask & reg_mask) | CAN_EFF_FLAG;
   s_socket_data.num_filters++;
 
   if (setsockopt(s_socket_data.can_fd, SOL_CAN_RAW, CAN_RAW_FILTER, s_socket_data.filters,

--- a/libraries/ms-common/src/x86/can_hw.c
+++ b/libraries/ms-common/src/x86/can_hw.c
@@ -133,9 +133,9 @@ StatusCode can_hw_init(const CANHwSettings *settings) {
 
     pthread_mutex_unlock(&s_keep_alive);
 
-    // Signal condition variable in case TX thread is waiting
     pthread_join(s_rx_pthread_id, NULL);
 
+    // Signal condition variable in case TX thread is waiting
     pthread_mutex_lock(&s_tx_mutex);
     pthread_mutex_unlock(&s_tx_mutex);
     pthread_cond_signal(&s_tx_cond);
@@ -208,7 +208,7 @@ StatusCode can_hw_register_callback(CANHwEvent event, CANHwEventHandlerCb callba
   return STATUS_CODE_OK;
 }
 
-StatusCode can_hw_add_filter(uint16_t mask, uint16_t filter) {
+StatusCode can_hw_add_filter(uint32_t mask, uint32_t filter, bool extended) {
   if (s_socket_data.num_filters >= CAN_HW_MAX_FILTERS) {
     return status_msg(STATUS_CODE_RESOURCE_EXHAUSTED, "CAN HW: Ran out of filters.");
   }
@@ -229,8 +229,10 @@ CANHwBusStatus can_hw_bus_status(void) {
   return CAN_HW_BUS_STATUS_OK;
 }
 
-StatusCode can_hw_transmit(uint16_t id, const uint8_t *data, size_t len) {
-  struct can_frame frame = { .can_id = id & CAN_SFF_MASK, .can_dlc = len };
+StatusCode can_hw_transmit(uint32_t id, bool extended, const uint8_t *data, size_t len) {
+  uint32_t mask = extended ? CAN_EFF_MASK : CAN_SFF_MASK;
+  uint32_t extended_bit = extended ? CAN_EFF_FLAG : 0;
+  struct can_frame frame = { .can_id = (id & mask) | extended_bit, .can_dlc = len };
   memcpy(&frame.data, data, len);
 
   pthread_mutex_lock(&s_tx_mutex);
@@ -248,13 +250,15 @@ StatusCode can_hw_transmit(uint16_t id, const uint8_t *data, size_t len) {
 }
 
 // Must be called within the RX handler, returns whether a message was processed
-bool can_hw_receive(uint16_t *id, uint64_t *data, size_t *len) {
+bool can_hw_receive(uint32_t *id, bool *extended, uint64_t *data, size_t *len) {
   if (s_socket_data.rx_frame.can_id == 0) {
     // Assumes that we'll never transmit something with a CAN ID of all 0s
     return false;
   }
 
-  *id = s_socket_data.rx_frame.can_id & CAN_SFF_MASK;
+  *extended = !!(s_socket_data.rx_frame.can_id & CAN_EFF_FLAG);
+  uint32_t mask = *extended ? CAN_EFF_MASK : CAN_SFF_MASK;
+  *id = s_socket_data.rx_frame.can_id & mask;
   memcpy(data, s_socket_data.rx_frame.data, sizeof(*data));
   *len = s_socket_data.rx_frame.can_dlc;
 

--- a/libraries/ms-common/test/test_can_hw.c
+++ b/libraries/ms-common/test/test_can_hw.c
@@ -108,10 +108,16 @@ void test_can_hw_extended(void) {
 void test_can_hw_extended_filter(void) {
   can_hw_add_filter(0x1234567, 0x1234567, true);
 
+  // No match extended - fail
   StatusCode ret = can_hw_transmit(0x1234547, true, 0, 0);
   TEST_ASSERT_OK(ret);
 
-  ret = can_hw_transmit(0x12, false, 0, 0);
+  // No match standard - fail
+  ret = can_hw_transmit(0x123, false, 0, 0);
+  TEST_ASSERT_OK(ret);
+
+  // Partial invalid - fail
+  ret = can_hw_transmit(0x0004567, true, 0, 0);
   TEST_ASSERT_OK(ret);
 
   ret = can_hw_transmit(0x1234567, true, 0, 0);

--- a/libraries/ms-common/test/test_can_hw.c
+++ b/libraries/ms-common/test/test_can_hw.c
@@ -5,12 +5,13 @@
 #include "unity.h"
 
 static volatile size_t s_msg_rx;
-static volatile uint16_t s_rx_id;
+static volatile uint32_t s_rx_id;
+static volatile bool s_extended;
 static volatile uint64_t s_rx_data;
 static volatile size_t s_rx_len;
 
 static void prv_handle_rx(void *context) {
-  while (can_hw_receive(&s_rx_id, &s_rx_data, &s_rx_len)) {
+  while (can_hw_receive(&s_rx_id, &s_extended, &s_rx_data, &s_rx_len)) {
     s_msg_rx++;
   }
 }
@@ -37,6 +38,7 @@ void setup_test(void) {
   TEST_ASSERT_OK(ret);
   s_msg_rx = 0;
   s_rx_id = 0;
+  s_extended = false;
   s_rx_data = 0;
   s_rx_len = 0;
   LOG_DEBUG("CAN initialized\n");
@@ -45,38 +47,79 @@ void setup_test(void) {
 void teardown_test(void) {}
 
 void test_can_hw_loop(void) {
-  uint16_t tx_id = 0x01;
+  uint32_t tx_id = 0x01;
   uint64_t tx_data = 0x1122334455667788;
   size_t tx_len = 8;
 
-  StatusCode ret = can_hw_transmit(tx_id, (uint8_t *)&tx_data, tx_len);
+  StatusCode ret = can_hw_transmit(tx_id, false, (uint8_t *)&tx_data, tx_len);
   TEST_ASSERT_OK(ret);
 
   prv_wait_rx(1);
 
   TEST_ASSERT_EQUAL(tx_id, s_rx_id);
+  TEST_ASSERT_EQUAL(false, s_extended);
   TEST_ASSERT_EQUAL(tx_data, s_rx_data);
   TEST_ASSERT_EQUAL(tx_len, s_rx_len);
 }
 
 void test_can_hw_filter(void) {
   // Mask 0b11, require 0b01
-  can_hw_add_filter(0x03, 0x01);
+  can_hw_add_filter(0x03, 0x01, false);
 
   // 0b0011 - fail
-  StatusCode ret = can_hw_transmit(0x3, 0, 0);
+  StatusCode ret = can_hw_transmit(0x3, false, 0, 0);
   TEST_ASSERT_OK(ret);
 
   // 0b0101 - pass
-  ret = can_hw_transmit(0x5, 0, 0);
+  ret = can_hw_transmit(0x5, false, 0, 0);
   TEST_ASSERT_OK(ret);
 
   // 0b00111001 - pass
-  ret = can_hw_transmit(0x39, 0, 0);
+  ret = can_hw_transmit(0x39, false, 0, 0);
+  TEST_ASSERT_OK(ret);
+
+  // extended ID with std ID 0b1 - fail
+  ret = can_hw_transmit(0x40000, true, 0, 0);
   TEST_ASSERT_OK(ret);
 
   prv_wait_rx(2);
 
   TEST_ASSERT_EQUAL(2, s_msg_rx);
+  TEST_ASSERT_EQUAL(false, s_extended);
   TEST_ASSERT_EQUAL(0x39, s_rx_id);
+}
+
+void test_can_hw_extended(void) {
+  uint32_t tx_id = 0x15555555;
+  uint64_t tx_data = 0x1122334455667788;
+  size_t tx_len = 8;
+
+  StatusCode ret = can_hw_transmit(tx_id, true, (uint8_t *)&tx_data, tx_len);
+  TEST_ASSERT_OK(ret);
+
+  prv_wait_rx(1);
+
+  TEST_ASSERT_EQUAL(tx_id, s_rx_id);
+  TEST_ASSERT_EQUAL(true, s_extended);
+  TEST_ASSERT_EQUAL(tx_data, s_rx_data);
+  TEST_ASSERT_EQUAL(tx_len, s_rx_len);
+}
+
+void test_can_hw_extended_filter(void) {
+  can_hw_add_filter(0x1234567, 0x12345678, true);
+
+  StatusCode ret = can_hw_transmit(0x1234547, true, 0, 0);
+  TEST_ASSERT_OK(ret);
+
+  ret = can_hw_transmit(0x12, false, 0, 0);
+  TEST_ASSERT_OK(ret);
+
+  ret = can_hw_transmit(0x1234567, true, 0, 0);
+  TEST_ASSERT_OK(ret);
+
+  prv_wait_rx(1);
+
+  TEST_ASSERT_EQUAL(1, s_msg_rx);
+  TEST_ASSERT_EQUAL(true, s_extended);
+  TEST_ASSERT_EQUAL(0x1234567, s_rx_id);
 }

--- a/libraries/ms-common/test/test_can_hw.c
+++ b/libraries/ms-common/test/test_can_hw.c
@@ -106,7 +106,7 @@ void test_can_hw_extended(void) {
 }
 
 void test_can_hw_extended_filter(void) {
-  can_hw_add_filter(0x1234567, 0x12345678, true);
+  can_hw_add_filter(0x1234567, 0x1234567, true);
 
   StatusCode ret = can_hw_transmit(0x1234547, true, 0, 0);
   TEST_ASSERT_OK(ret);


### PR DESCRIPTION
Adds extended ID support to CAN HW. This will be used for CAN <-> UART interfaces.

Also fixes clang-format not using our format file.