### PR TITLE
ELEC-326, ELEC-327: Fix hash file updating and bump CAN ACK timeout

### DIFF
--- a/libraries/ms-common/inc/can_ack.h
+++ b/libraries/ms-common/inc/can_ack.h
@@ -19,7 +19,7 @@
 
 // ACK timeout: Should account for transit and computation time
 // Note that this timeout is currently an arbitrary value, but should be minimized.
-#define CAN_ACK_TIMEOUT_MS 10
+#define CAN_ACK_TIMEOUT_MS 15
 #define CAN_ACK_MAX_REQUESTS 10
 
 // Converts devices IDs to their bitset form. Populate ACK request bitsets using this.

--- a/make/git_fetch.py
+++ b/make/git_fetch.py
@@ -77,14 +77,9 @@ def check_hash(filename, hash_file):
         with open(hash_file, 'r+') as hashfp:
             if hashfp.readline() == stdout.decode('utf-8'):
                 return True
-            else:
-                hashfp.truncate(0)
-                hashfp.write(stdout.decode('utf-8'))
-                hashfp.flush()
-    else:
-        with open(hash_file, 'w+') as hashfp:
-            hashfp.write(stdout.decode('utf-8'))
-            hashfp.flush()
+    with open(hash_file, 'w+') as hashfp:
+        hashfp.write(stdout.decode('utf-8'))
+        hashfp.flush()
     return False
 
 


### PR DESCRIPTION
* Refactor the logic to update the hash file 
* Bump CAN ACK timeout from 10ms to 15ms