### PR TITLE
ELEC-328: Fixed SPI prescaler

### DIFF
--- a/libraries/ms-common/inc/spi.h
+++ b/libraries/ms-common/inc/spi.h
@@ -24,6 +24,8 @@ typedef struct {
   GPIOAddress cs;
 } SPISettings;
 
+// Note that our prescalers on STM32 must be a power of 2, so the actual baudrate may not be
+// exactly as requested. Please verify that the actual baudrate is within bounds.
 StatusCode spi_init(SPIPort spi, const SPISettings *settings);
 
 StatusCode spi_exchange(SPIPort spi, uint8_t *tx_data, size_t tx_len, uint8_t *rx_data,

--- a/libraries/ms-common/src/stm32f0xx/spi.c
+++ b/libraries/ms-common/src/stm32f0xx/spi.c
@@ -24,7 +24,7 @@ StatusCode spi_init(SPIPort spi, const SPISettings *settings) {
   RCC_ClocksTypeDef clocks;
   RCC_GetClocksFreq(&clocks);
 
-  size_t index = (size_t)__builtin_ffsl((int32_t)(clocks.PCLK_Frequency / settings->baudrate));
+  size_t index = 32 - (size_t)__builtin_clz(clocks.PCLK_Frequency / settings->baudrate);
   if (index <= 2) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid baudrate");
   }

--- a/libraries/ms-common/src/stm32f0xx/spi.c
+++ b/libraries/ms-common/src/stm32f0xx/spi.c
@@ -24,8 +24,13 @@ StatusCode spi_init(SPIPort spi, const SPISettings *settings) {
   RCC_ClocksTypeDef clocks;
   RCC_GetClocksFreq(&clocks);
 
+  // See stm32f0xx_spi.h or SPIx_CR1->BR for valid prescalers
+  // Since they must be powers of two with a minimum prescaler of /2,
+  // we find the largest power of two in the requested divider and offset it such that
+  // BR = f_PCLK / 2 = 0x00
+  // and shift it to the correct position.
   size_t index = 32 - (size_t)__builtin_clz(clocks.PCLK_Frequency / settings->baudrate);
-  if (index <= 2) {
+  if (index < 2) {
     return status_msg(STATUS_CODE_INVALID_ARGS, "Invalid baudrate");
   }
 


### PR DESCRIPTION
I was using ffs when I should've been using clz. Now properly calculates a reasonable prescaler.

Note that there a limited number of supported baudrates - i.e. 1MHz will actually be 48MHz/32 = 1.5MHz. I was thinking of just making those enums so it's more clear, but it's dependent on our PCLK frequency.