### PR TITLE
ELEC-105: [Chaos] Finished Power Path API

### DIFF
--- a/projects/chaos/inc/chaos_events.h
+++ b/projects/chaos/inc/chaos_events.h
@@ -2,18 +2,42 @@
 
 // High priority messages in the event queue
 typedef enum {
-  NUM_CHAOS_EVENTS_CRITICAL = 0,
-} ChaosEventCritical;
+  CHAOS_EVENT_RELAY_ERROR = 0,
+  NUM_CHAOS_EVENTS_CRITICAL,  // 1
+} ChaosEventsCritical;
 
-// CAN messages in the event queue
+// CAN related messages in the event queue
 typedef enum {
-  CHAOS_EVENT_CAN_UV_OV = NUM_CHAOS_EVENTS_CRITICAL + 1,
-  NUM_CHAOS_EVENTS_CAN,
-} ChaosEventCAN;
+  CHAOS_EVENT_CAN_TRANSMIT_ERROR = NUM_CHAOS_EVENTS_CRITICAL + 1,  // 2
+  CHAOS_EVENT_CAN_FAULT,
+  CHAOS_EVENT_CAN_RX,
+  CHAOS_EVENT_CAN_TX,
+  CHAOS_EVENT_RETRY_RELAY,
+  NUM_CHAOS_EVENTS_CAN,  // 7
+} ChaosEventsCAN;
 
-// State transition messages in the event queue
+// State transition messages in the event queue (only 1 should be in the queue at a time so order is
+// irrelevant).
 typedef enum {
-  NUM_CHAOS_EVENTS_FSM = NUM_CHAOS_EVENTS_CAN + 1,
-} ChaosEventFSM;
+  CHAOS_EVENT_NO_OP = NUM_CHAOS_EVENTS_CAN + 1,  // 8
+  CHAOS_EVENT_MONITOR_ENABLE,
+  CHAOS_EVENT_MONITOR_DISABLE,
+  CHAOS_EVENT_OPEN_RELAY,
+  CHAOS_EVENT_CLOSE_RELAY,
+  CHAOS_EVENT_RELAY_OPENED,
+  CHAOS_EVENT_RELAY_CLOSED,
+  CHAOS_EVENT_GPIO_IDLE,
+  CHAOS_EVENT_GPIO_CHARGE,
+  CHAOS_EVENT_GPIO_DRIVE,
+  NUM_CHAOS_EVENTS_FSM  // 18
+} ChaosEventsFSM;
+
+typedef enum {
+  CHAOS_EVENT_SEQUENCE_IDLE = NUM_CHAOS_EVENTS_FSM + 1,  // 19
+  CHAOS_EVENT_SEQUENCE_CHARGE,
+  CHAOS_EVENT_SEQUENCE_DRIVE,
+  CHAOS_EVENT_SEQUENCE_RESET,
+  NUM_CHAOS_EVENT_SEQUENCES,  // 23
+} ChaosEventSequence;
 
 #define NUM_CHAOS_EVENTS NUM_CHAOS_EVENTS_FSM

--- a/projects/chaos/inc/chaos_events.h
+++ b/projects/chaos/inc/chaos_events.h
@@ -32,6 +32,7 @@ typedef enum {
   NUM_CHAOS_EVENTS_FSM  // 18
 } ChaosEventsFSM;
 
+// Used for the sequence generator that schedules and order events for the other FSMs.
 typedef enum {
   CHAOS_EVENT_SEQUENCE_IDLE = NUM_CHAOS_EVENTS_FSM + 1,  // 19
   CHAOS_EVENT_SEQUENCE_CHARGE,
@@ -40,4 +41,4 @@ typedef enum {
   NUM_CHAOS_EVENT_SEQUENCES,  // 23
 } ChaosEventSequence;
 
-#define NUM_CHAOS_EVENTS NUM_CHAOS_EVENTS_FSM
+#define NUM_CHAOS_EVENTS NUM_CHAOS_EVENT_SEQUENCES

--- a/projects/chaos/inc/power_path.h
+++ b/projects/chaos/inc/power_path.h
@@ -6,6 +6,7 @@
 #include <stdint.h>
 
 #include "adc.h"
+#include "event_queue.h"
 #include "gpio.h"
 #include "soft_timer.h"
 #include "status.h"
@@ -58,3 +59,7 @@ StatusCode power_path_source_monitor_disable(PowerPathSource *source);
 
 // Reads the latest voltage and current from the specified power source.
 StatusCode power_path_read_source(const PowerPathSource *source, PowerPathVCReadings *values);
+
+// A function to update the power path based on an event rather than a direct function call, meant
+// to emulate fsm_process_event with additional args.
+bool power_path_process_event(PowerPathCfg *cfg, const Event *e);

--- a/projects/chaos/src/power_path.c
+++ b/projects/chaos/src/power_path.c
@@ -4,13 +4,22 @@
 #include <string.h>
 
 #include "adc.h"
+#include "can_msg_defs.h"
+#include "can_transmit.h"
 #include "chaos_events.h"
 #include "event_queue.h"
 #include "gpio.h"
 #include "gpio_it.h"
 #include "interrupt.h"
+#include "log.h"
 #include "soft_timer.h"
 #include "status.h"
+
+// All values in millivolts
+#define POWER_PATH_AUX_UV 8460
+#define POWER_PATH_AUX_OV 14310
+#define POWER_PATH_DCDC_UV 11160
+#define POWER_PATH_DCDC_OV 12840
 
 // Evaluates if two GPIO addresses are equal.
 static bool prv_addr_eq(GPIOAddress addr1, GPIOAddress addr2) {
@@ -20,10 +29,21 @@ static bool prv_addr_eq(GPIOAddress addr1, GPIOAddress addr2) {
 // Interrupt handler for over and under voltage warnings.
 static void prv_voltage_warning(const GPIOAddress *addr, void *context) {
   PowerPathCfg *pp = context;
+  PowerPathVCReadings readings = { 0 };
+  StatusCode status = STATUS_CODE_OK;
   if (prv_addr_eq(*addr, pp->dcdc.uv_ov_pin) && pp->dcdc.monitoring_active) {
-    event_raise(CHAOS_EVENT_CAN_UV_OV, POWER_PATH_SOURCE_ID_DCDC);
+    power_path_read_source(&pp->dcdc, &readings);
+    LOG_DEBUG("DCDC\n");
+    status = CAN_TRANSMIT_OVUV_DCDC_AUX((readings.voltage >= POWER_PATH_DCDC_OV),
+                                        (readings.voltage <= POWER_PATH_DCDC_UV), false, false);
   } else if (prv_addr_eq(*addr, pp->aux_bat.uv_ov_pin) && pp->aux_bat.monitoring_active) {
-    event_raise(CHAOS_EVENT_CAN_UV_OV, POWER_PATH_SOURCE_ID_AUX_BAT);
+    power_path_read_source(&pp->aux_bat, &readings);
+    LOG_DEBUG("AUX\n");
+    status = CAN_TRANSMIT_OVUV_DCDC_AUX(false, false, (readings.voltage >= POWER_PATH_AUX_OV),
+                                        (readings.voltage <= POWER_PATH_AUX_UV));
+  }
+  if (!status_ok(status)) {
+    event_raise(CHAOS_EVENT_CAN_TRANSMIT_ERROR, CAN_MESSAGE_OVUV_DCDC_AUX);
   }
 }
 
@@ -131,4 +151,25 @@ StatusCode power_path_read_source(const PowerPathSource *source, PowerPathVCRead
 
   *values = source->readings;
   return STATUS_CODE_OK;
+}
+
+bool power_path_process_event(PowerPathCfg *cfg, const Event *e) {
+  PowerPathSource *source = NULL;
+  if (e->data == POWER_PATH_SOURCE_ID_DCDC) {
+    PowerPathSource *source = &cfg->dcdc;
+  } else if (e->data == POWER_PATH_SOURCE_ID_AUX_BAT) {
+    PowerPathSource *source = &cfg->aux_bat;
+  } else {
+    return false;
+  }
+
+  if (e->id == CHAOS_EVENT_MONITOR_ENABLE) {
+    power_path_source_monitor_enable(source, source->period_us);
+    return true;
+  } else if (e->id == CHAOS_EVENT_MONITOR_DISABLE) {
+    power_path_source_monitor_disable(source);
+    return true;
+  }
+
+  return false;
 }

--- a/projects/chaos/src/power_path.c
+++ b/projects/chaos/src/power_path.c
@@ -16,10 +16,10 @@
 #include "status.h"
 
 // All values in millivolts
-#define POWER_PATH_AUX_UV 8460
-#define POWER_PATH_AUX_OV 14310
-#define POWER_PATH_DCDC_UV 11160
-#define POWER_PATH_DCDC_OV 12840
+#define POWER_PATH_AUX_UV_MILLIV 8460
+#define POWER_PATH_AUX_OV_MILLIV 14310
+#define POWER_PATH_DCDC_UV_MILLIV 11160
+#define POWER_PATH_DCDC_OV_MILLIV 12840
 
 // Evaluates if two GPIO addresses are equal.
 static bool prv_addr_eq(GPIOAddress addr1, GPIOAddress addr2) {
@@ -33,14 +33,14 @@ static void prv_voltage_warning(const GPIOAddress *addr, void *context) {
   StatusCode status = STATUS_CODE_OK;
   if (prv_addr_eq(*addr, pp->dcdc.uv_ov_pin) && pp->dcdc.monitoring_active) {
     power_path_read_source(&pp->dcdc, &readings);
-    LOG_DEBUG("DCDC\n");
-    status = CAN_TRANSMIT_OVUV_DCDC_AUX((readings.voltage >= POWER_PATH_DCDC_OV),
-                                        (readings.voltage <= POWER_PATH_DCDC_UV), false, false);
+    status =
+        CAN_TRANSMIT_OVUV_DCDC_AUX((readings.voltage >= POWER_PATH_DCDC_OV_MILLIV),
+                                   (readings.voltage <= POWER_PATH_DCDC_UV_MILLIV), false, false);
   } else if (prv_addr_eq(*addr, pp->aux_bat.uv_ov_pin) && pp->aux_bat.monitoring_active) {
     power_path_read_source(&pp->aux_bat, &readings);
-    LOG_DEBUG("AUX\n");
-    status = CAN_TRANSMIT_OVUV_DCDC_AUX(false, false, (readings.voltage >= POWER_PATH_AUX_OV),
-                                        (readings.voltage <= POWER_PATH_AUX_UV));
+    status =
+        CAN_TRANSMIT_OVUV_DCDC_AUX(false, false, (readings.voltage >= POWER_PATH_AUX_OV_MILLIV),
+                                   (readings.voltage <= POWER_PATH_AUX_UV_MILLIV));
   }
   if (!status_ok(status)) {
     event_raise(CHAOS_EVENT_CAN_TRANSMIT_ERROR, CAN_MESSAGE_OVUV_DCDC_AUX);
@@ -156,9 +156,9 @@ StatusCode power_path_read_source(const PowerPathSource *source, PowerPathVCRead
 bool power_path_process_event(PowerPathCfg *cfg, const Event *e) {
   PowerPathSource *source = NULL;
   if (e->data == POWER_PATH_SOURCE_ID_DCDC) {
-    PowerPathSource *source = &cfg->dcdc;
+    source = &cfg->dcdc;
   } else if (e->data == POWER_PATH_SOURCE_ID_AUX_BAT) {
-    PowerPathSource *source = &cfg->aux_bat;
+    source = &cfg->aux_bat;
   } else {
     return false;
   }

--- a/projects/chaos/test/test_power_path.c
+++ b/projects/chaos/test/test_power_path.c
@@ -26,24 +26,24 @@
 #define TEST_POWER_PATH_ADC_PERIOD_US 1000
 
 #define TEST_POWER_PATH_AUX_CURRENT_VAL 1
-#define TEST_POWER_PATH_AUX_VOLTAGE_VAL 2
+#define TEST_POWER_PATH_AUX_UV_VAL 2
 #define TEST_POWER_PATH_DCDC_CURRENT_VAL 3
-#define TEST_POWER_PATH_DCDC_VOLTAGE_VAL 4
+#define TEST_POWER_PATH_DCDC_UV_VAL 4
 
 static uint16_t prv_aux_current_convert(uint16_t value) {
   return TEST_POWER_PATH_AUX_CURRENT_VAL;
 }
 
-static uint16_t prv_aux_voltage_convert(uint16_t value) {
-  return TEST_POWER_PATH_AUX_VOLTAGE_VAL;
+static uint16_t prv_aux_undervoltage_convert(uint16_t value) {
+  return TEST_POWER_PATH_AUX_UV_VAL;
 }
 
 static uint16_t prv_dcdc_current_convert(uint16_t value) {
   return TEST_POWER_PATH_DCDC_CURRENT_VAL;
 }
 
-static uint16_t prv_dcdc_voltage_convert(uint16_t value) {
-  return TEST_POWER_PATH_DCDC_VOLTAGE_VAL;
+static uint16_t prv_dcdc_undervoltage_convert(uint16_t value) {
+  return TEST_POWER_PATH_DCDC_UV_VAL;
 }
 
 static volatile uint8_t s_dcdc_ov = UINT8_MAX;
@@ -65,7 +65,7 @@ static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
                                            .current_pin = { .port = 0, .pin = 4 },
                                            .readings = { .voltage = 0, .current = 0 },
                                            .current_convert_fn = prv_aux_current_convert,
-                                           .voltage_convert_fn = prv_aux_voltage_convert,
+                                           .voltage_convert_fn = prv_aux_undervoltage_convert,
                                            .period_us = 0,
                                            .timer_id = SOFT_TIMER_INVALID_TIMER,
                                            .monitoring_active = false },
@@ -75,7 +75,7 @@ static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
                                         .current_pin = { .port = 0, .pin = 7 },
                                         .readings = { .voltage = 0, .current = 0 },
                                         .current_convert_fn = prv_dcdc_current_convert,
-                                        .voltage_convert_fn = prv_dcdc_voltage_convert,
+                                        .voltage_convert_fn = prv_dcdc_undervoltage_convert,
                                         .period_us = 0,
                                         .timer_id = SOFT_TIMER_INVALID_TIMER,
                                         .monitoring_active = false } };
@@ -170,10 +170,10 @@ void test_power_path_adcs(void) {
   PowerPathVCReadings readings = { 0, 0 };
   TEST_ASSERT_OK(power_path_read_source(&s_ppc.aux_bat, &readings));
   TEST_ASSERT_EQUAL(TEST_POWER_PATH_AUX_CURRENT_VAL, readings.current);
-  TEST_ASSERT_EQUAL(TEST_POWER_PATH_AUX_VOLTAGE_VAL, readings.voltage);
+  TEST_ASSERT_EQUAL(TEST_POWER_PATH_AUX_UV_VAL, readings.voltage);
   TEST_ASSERT_OK(power_path_read_source(&s_ppc.dcdc, &readings));
   TEST_ASSERT_EQUAL(TEST_POWER_PATH_DCDC_CURRENT_VAL, readings.current);
-  TEST_ASSERT_EQUAL(TEST_POWER_PATH_DCDC_VOLTAGE_VAL, readings.voltage);
+  TEST_ASSERT_EQUAL(TEST_POWER_PATH_DCDC_UV_VAL, readings.voltage);
 
   TEST_ASSERT_OK(power_path_source_monitor_disable(&s_ppc.aux_bat));
   TEST_ASSERT_OK(power_path_source_monitor_disable(&s_ppc.dcdc));

--- a/projects/chaos/test/test_power_path.c
+++ b/projects/chaos/test/test_power_path.c
@@ -4,17 +4,24 @@
 #include <stdint.h>
 
 #include "adc.h"
+#include "can.h"
+#include "can_msg_defs.h"
+#include "can_unpack.h"
 #include "chaos_events.h"
 #include "delay.h"
 #include "event_queue.h"
+#include "fsm.h"
 #include "gpio.h"
 #include "gpio_it.h"
 #include "interrupt.h"
 #include "log.h"
+#include "misc.h"
 #include "soft_timer.h"
 #include "status.h"
 #include "test_helpers.h"
 #include "unity.h"
+
+#define TEST_POWER_PATH_NUM_RX_HANDLERS 1
 
 #define TEST_POWER_PATH_ADC_PERIOD_US 1000
 
@@ -37,6 +44,17 @@ static uint16_t prv_dcdc_current_convert(uint16_t value) {
 
 static uint16_t prv_dcdc_voltage_convert(uint16_t value) {
   return TEST_POWER_PATH_DCDC_VOLTAGE_VAL;
+}
+
+static volatile uint8_t s_dcdc_ov = UINT8_MAX;
+static volatile uint8_t s_dcdc_uv = UINT8_MAX;
+static volatile uint8_t s_aux_ov = UINT8_MAX;
+static volatile uint8_t s_aux_uv = UINT8_MAX;
+
+static StatusCode prv_handle_uvov(const CANMessage *msg, void *context, CANAckStatus *ack_reply) {
+  LOG_DEBUG("Handled\n");
+  CAN_UNPACK_OVUV_DCDC_AUX(msg, &s_dcdc_ov, &s_dcdc_uv, &s_aux_ov, &s_aux_uv);
+  return STATUS_CODE_OK;
 }
 
 static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
@@ -62,34 +80,82 @@ static PowerPathCfg s_ppc = { .enable_pin = { .port = 0, .pin = 0 },
                                         .timer_id = SOFT_TIMER_INVALID_TIMER,
                                         .monitoring_active = false } };
 
+static CANStorage s_can_storage;
+static CANRxHandler s_rx_handlers[TEST_POWER_PATH_NUM_RX_HANDLERS];
+
 void setup_test(void) {
   event_queue_init();
-  gpio_init();
   interrupt_init();
-  gpio_it_init();
   soft_timer_init();
+  gpio_init();
+  gpio_it_init();
   adc_init(ADC_MODE_SINGLE);
+
+  CANSettings can_settings = {
+    .device_id = CAN_DEVICE_CHAOS,
+    .bitrate = CAN_HW_BITRATE_125KBPS,
+    .rx_event = CHAOS_EVENT_CAN_RX,
+    .tx_event = CHAOS_EVENT_CAN_TX,
+    .fault_event = CHAOS_EVENT_CAN_FAULT,
+    .tx = { GPIO_PORT_A, 12 },
+    .rx = { GPIO_PORT_A, 11 },
+    .loopback = true,
+  };
+
+  TEST_ASSERT_OK(
+      can_init(&can_settings, &s_can_storage, s_rx_handlers, SIZEOF_ARRAY(s_rx_handlers)));
   TEST_ASSERT_OK(power_path_init(&s_ppc));
 }
 
 void teardown_test(void) {}
 
 void test_power_path_uv_ov(void) {
+  volatile CANMessage rx_msg = { 0 };
+  can_register_rx_handler(CAN_MESSAGE_OVUV_DCDC_AUX, prv_handle_uvov, &rx_msg);
+
   TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.aux_bat, TEST_POWER_PATH_ADC_PERIOD_US));
   TEST_ASSERT_OK(power_path_source_monitor_enable(&s_ppc.dcdc, TEST_POWER_PATH_ADC_PERIOD_US));
 
+  delay_us(TEST_POWER_PATH_ADC_PERIOD_US + TEST_POWER_PATH_ADC_PERIOD_US / 10);
+
   gpio_it_trigger_interrupt(&s_ppc.aux_bat.uv_ov_pin);
-  Event e = { 0, 0 };
-  while (event_process(&e) != STATUS_CODE_OK) {
-  }
-  TEST_ASSERT_EQUAL(CHAOS_EVENT_CAN_UV_OV, e.id);
-  TEST_ASSERT_EQUAL(POWER_PATH_SOURCE_ID_AUX_BAT, e.data);
+
+  volatile Event e = { 0 };
+  volatile StatusCode status = NUM_STATUS_CODES;
+
+  // TX
+  do {
+    status = event_process(&e);
+  } while (status != STATUS_CODE_OK);
+  TEST_ASSERT_TRUE(fsm_process_event(CAN_FSM, &e));
+  // RX
+  do {
+    status = event_process(&e);
+  } while (status != STATUS_CODE_OK);
+  TEST_ASSERT_TRUE(fsm_process_event(CAN_FSM, &e));
+
+  TEST_ASSERT_EQUAL(false, s_dcdc_uv);
+  TEST_ASSERT_EQUAL(false, s_dcdc_ov);
+  TEST_ASSERT_EQUAL(true, s_aux_uv);
+  TEST_ASSERT_EQUAL(false, s_aux_ov);
 
   gpio_it_trigger_interrupt(&s_ppc.dcdc.uv_ov_pin);
-  while (event_process(&e) != STATUS_CODE_OK) {
-  }
-  TEST_ASSERT_EQUAL(CHAOS_EVENT_CAN_UV_OV, e.id);
-  TEST_ASSERT_EQUAL(POWER_PATH_SOURCE_ID_DCDC, e.data);
+
+  // TX
+  do {
+    status = event_process(&e);
+  } while (status != STATUS_CODE_OK);
+  TEST_ASSERT_TRUE(fsm_process_event(CAN_FSM, &e));
+  // RX
+  do {
+    status = event_process(&e);
+  } while (status != STATUS_CODE_OK);
+  TEST_ASSERT_TRUE(fsm_process_event(CAN_FSM, &e));
+
+  TEST_ASSERT_EQUAL(true, s_dcdc_uv);
+  TEST_ASSERT_EQUAL(false, s_dcdc_ov);
+  TEST_ASSERT_EQUAL(false, s_aux_uv);
+  TEST_ASSERT_EQUAL(false, s_aux_ov);
 
   TEST_ASSERT_OK(power_path_source_monitor_disable(&s_ppc.aux_bat));
   TEST_ASSERT_OK(power_path_source_monitor_disable(&s_ppc.dcdc));


### PR DESCRIPTION
This is the first in a multi-part series of PRs to merge the contents of `elec_105_chaos_can` into `master`.

This PR does the following:
- Changes errors from raising events to publishing CAN events
- Fills in the `chaos_events.h` file
- Updates the test for `power_path`
- Adds an alternative interface to the Power Path API that uses events to make changes (all other modules in Chaos will share the same interface to allow them to all hook into the main event loop)