### PR TITLE
ELEC-321: LSC Unify Callback Style

### DIFF
--- a/libraries/libcore/inc/status.h
+++ b/libraries/libcore/inc/status.h
@@ -63,7 +63,7 @@ typedef struct Status {
   const char *message;
 } Status;
 
-typedef void (*status_callback)(const Status *status);
+typedef void (*StatusCallback)(const Status *status);
 
 // Updates a status struct containing an error code and optionally a message. This should only be
 // called via the macros.
@@ -74,7 +74,7 @@ StatusCode status_impl_update(StatusCode code, const char *source, const char *c
 Status status_get(void);
 
 // Set a callback that is run whenever the status is changed.
-void status_register_callback(status_callback callback);
+void status_register_callback(StatusCallback callback);
 
 // Macros for convenience.
 #define status_code(code) \

--- a/libraries/libcore/src/status.c
+++ b/libraries/libcore/src/status.c
@@ -7,7 +7,7 @@ static Status s_global_status = {
   .caller = "",   //
   .message = "",  //
 };
-static status_callback s_callback;
+static StatusCallback s_callback;
 
 StatusCode status_impl_update(const StatusCode code, const char* source, const char* caller,
                               const char* message) {
@@ -25,6 +25,6 @@ Status status_get(void) {
   return s_global_status;
 }
 
-void status_register_callback(status_callback callback) {
+void status_register_callback(StatusCallback callback) {
   s_callback = callback;
 }

--- a/libraries/ms-common/inc/gpio_it.h
+++ b/libraries/ms-common/inc/gpio_it.h
@@ -8,14 +8,14 @@
 #include "interrupt_def.h"
 #include "status.h"
 
-typedef void (*gpio_it_callback)(const GPIOAddress *address, void *context);
+typedef void (*GPIOItCallback)(const GPIOAddress *address, void *context);
 
 // Initializes the interrupt handler for GPIO.
 void gpio_it_init(void);
 
 // Registers a new callback on a given port pin combination with the desired settings.
 StatusCode gpio_it_register_interrupt(const GPIOAddress *address, const InterruptSettings *settings,
-                                      InterruptEdge edge, gpio_it_callback callback, void *context);
+                                      InterruptEdge edge, GPIOItCallback callback, void *context);
 
 // Triggers an interrupt in software.
 StatusCode gpio_it_trigger_interrupt(const GPIOAddress *address);

--- a/libraries/ms-common/inc/objpool.h
+++ b/libraries/ms-common/inc/objpool.h
@@ -13,12 +13,12 @@
 #define OBJPOOL_MAX_NODES 64
 
 // Function to initialize nodes with
-typedef void (*objpool_node_init_fn)(void *node, void *context);
+typedef void (*ObjpoolNodeInitFn)(void *node, void *context);
 
 typedef struct ObjectPool {
   void *nodes;
   void *context;
-  objpool_node_init_fn init_node;
+  ObjpoolNodeInitFn init_node;
   size_t num_nodes;
   size_t node_size;
   uint64_t free_bitset;
@@ -31,7 +31,7 @@ typedef struct ObjectPool {
 
 // Initializes an object pool. The specified context is provided for node initialization.
 StatusCode objpool_init_verbose(ObjectPool *pool, void *nodes, size_t node_size, size_t num_nodes,
-                                objpool_node_init_fn init_node, void *context);
+                                ObjpoolNodeInitFn init_node, void *context);
 
 // Returns the pointer to an object from the pool.
 void *objpool_get_node(ObjectPool *pool);

--- a/libraries/ms-common/src/objpool.c
+++ b/libraries/ms-common/src/objpool.c
@@ -19,7 +19,7 @@
   ((size_t)((uint8_t *)(node) - (uint8_t *)(pool)->nodes) / (pool->node_size))
 
 StatusCode objpool_init_verbose(ObjectPool *pool, void *nodes, size_t node_size, size_t num_nodes,
-                                objpool_node_init_fn init_node, void *context) {
+                                ObjpoolNodeInitFn init_node, void *context) {
   if (num_nodes > OBJPOOL_MAX_NODES) {
     return status_code(STATUS_CODE_OUT_OF_RANGE);
   }

--- a/libraries/ms-common/src/stm32f0xx/gpio_it.c
+++ b/libraries/ms-common/src/stm32f0xx/gpio_it.c
@@ -35,8 +35,7 @@ static uint8_t prv_get_irq_channel(uint8_t pin) {
 }
 
 StatusCode gpio_it_register_interrupt(const GPIOAddress *address, const InterruptSettings *settings,
-                                      InterruptEdge edge, GPIOItCallback callback,
-                                      void *context) {
+                                      InterruptEdge edge, GPIOItCallback callback, void *context) {
   if (address->port >= NUM_GPIO_PORTS || address->pin >= GPIO_PINS_PER_PORT) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   } else if (s_gpio_it_interrupts[address->pin].callback) {

--- a/libraries/ms-common/src/stm32f0xx/gpio_it.c
+++ b/libraries/ms-common/src/stm32f0xx/gpio_it.c
@@ -11,7 +11,7 @@
 
 typedef struct GPIOITInterrupt {
   GPIOAddress address;
-  gpio_it_callback callback;
+  GPIOItCallback callback;
   void *context;
 } GPIOITInterrupt;
 
@@ -35,7 +35,7 @@ static uint8_t prv_get_irq_channel(uint8_t pin) {
 }
 
 StatusCode gpio_it_register_interrupt(const GPIOAddress *address, const InterruptSettings *settings,
-                                      InterruptEdge edge, gpio_it_callback callback,
+                                      InterruptEdge edge, GPIOItCallback callback,
                                       void *context) {
   if (address->port >= NUM_GPIO_PORTS || address->pin >= GPIO_PINS_PER_PORT) {
     return status_code(STATUS_CODE_INVALID_ARGS);

--- a/libraries/ms-common/src/x86/gpio_it.c
+++ b/libraries/ms-common/src/x86/gpio_it.c
@@ -11,7 +11,7 @@
 typedef struct GPIOITInterrupt {
   uint8_t interrupt_id;
   GPIOAddress address;
-  gpio_it_callback callback;
+  GPIOItCallback callback;
   void *context;
 } GPIOITInterrupt;
 
@@ -38,7 +38,7 @@ void gpio_it_init(void) {
 }
 
 StatusCode gpio_it_register_interrupt(const GPIOAddress *address, const InterruptSettings *settings,
-                                      InterruptEdge edge, gpio_it_callback callback,
+                                      InterruptEdge edge, GPIOItCallback callback,
                                       void *context) {
   if (address->port >= NUM_GPIO_PORTS || address->pin >= GPIO_PINS_PER_PORT) {
     return status_code(STATUS_CODE_INVALID_ARGS);

--- a/libraries/ms-common/src/x86/gpio_it.c
+++ b/libraries/ms-common/src/x86/gpio_it.c
@@ -38,8 +38,7 @@ void gpio_it_init(void) {
 }
 
 StatusCode gpio_it_register_interrupt(const GPIOAddress *address, const InterruptSettings *settings,
-                                      InterruptEdge edge, GPIOItCallback callback,
-                                      void *context) {
+                                      InterruptEdge edge, GPIOItCallback callback, void *context) {
   if (address->port >= NUM_GPIO_PORTS || address->pin >= GPIO_PINS_PER_PORT) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   } else if (s_gpio_it_interrupts[address->pin].callback) {

--- a/libraries/ms-helper/inc/debouncer.h
+++ b/libraries/ms-helper/inc/debouncer.h
@@ -13,11 +13,11 @@
 typedef struct DebouncerInfo {
   GPIOAddress address;
   GPIOState state;
-  gpio_it_callback callback;
+  GPIOItCallback callback;
   void *context;
 } DebouncerInfo;
 
 // Inits the GPIO input pin and sets up the debouncer for it.
 // debouncer_info is a storage created by the user, and it should persist.
 StatusCode debouncer_init_pin(DebouncerInfo *debouncer_info, const GPIOAddress *address,
-                              gpio_it_callback callback, void *context);
+                              GPIOItCallback callback, void *context);

--- a/libraries/ms-helper/src/debouncer.c
+++ b/libraries/ms-helper/src/debouncer.c
@@ -33,7 +33,7 @@ static void prv_it_callback(const GPIOAddress *address, void *context) {
 }
 
 StatusCode debouncer_init_pin(DebouncerInfo *debouncer_info, const GPIOAddress *address,
-                              gpio_it_callback callback, void *context) {
+                              GPIOItCallback callback, void *context) {
   GPIOSettings gpio_settings = {
     .direction = GPIO_DIR_IN,   //
     .resistor = GPIO_RES_NONE,  //

--- a/libraries/x86/inc/x86_interrupt.h
+++ b/libraries/x86/inc/x86_interrupt.h
@@ -5,7 +5,7 @@
 #include "interrupt_def.h"
 #include "status.h"
 
-typedef void (*x86_interrupt_handler)(uint8_t interrupt_id);
+typedef void (*x86InterruptHandler)(uint8_t interrupt_id);
 
 // Initializes the interrupt internals. If called multiple times the subsequent attempts will clear
 // everything resulting in the need to re initialize all interrupts.
@@ -13,7 +13,7 @@ void x86_interrupt_init(void);
 
 // Registers an ISR handler. The handler_id is updated to the id assigned to the handler if
 // registered successfully.
-StatusCode x86_interrupt_register_handler(x86_interrupt_handler handler, uint8_t* handler_id);
+StatusCode x86_interrupt_register_handler(x86InterruptHandler handler, uint8_t* handler_id);
 
 // Registers a callback to a handler assigning it a new id from the global interrupt id pool.
 StatusCode x86_interrupt_register_interrupt(uint8_t handler_id, const InterruptSettings* settings,

--- a/libraries/x86/src/x86_interrupt.c
+++ b/libraries/x86/src/x86_interrupt.c
@@ -24,7 +24,7 @@ static uint8_t s_x86_interrupt_next_interrupt_id = 0;
 static uint8_t s_x86_interrupt_next_handler_id = 0;
 
 static Interrupt s_x86_interrupt_interrupts_map[NUM_X86_INTERRUPT_INTERRUPTS];
-static x86InterruptHandler s_x86InterruptHandlers[NUM_X86_INTERRUPT_HANDLERS];
+static x86InterruptHandler s_x86_interrupt_handlers[NUM_X86_INTERRUPT_HANDLERS];
 
 // Signal handler for all interrupts. Prioritization is handled by the implementation of signals and
 // the init function. Signals of higher priority interrupt the running of this function. All other
@@ -36,7 +36,7 @@ void prv_sig_handler(int signum, siginfo_t *info, void *ptr) {
     if (!s_x86_interrupt_interrupts_map[info->si_value.sival_int].is_event) {
       // Execute the handler passing it the interrupt ID. To determine which handler look up in
       // the interrupts map by interrupt ID.
-      s_x86InterruptHandlers[s_x86_interrupt_interrupts_map[info->si_value.sival_int].handler_id](
+      s_x86_interrupt_handlers[s_x86_interrupt_interrupts_map[info->si_value.sival_int].handler_id](
           info->si_value.sival_int);
     }
   }
@@ -75,7 +75,7 @@ void x86_interrupt_init(void) {
   s_x86_interrupt_next_handler_id = 0;
 
   memset(&s_x86_interrupt_interrupts_map, 0, sizeof(s_x86_interrupt_interrupts_map));
-  memset(&s_x86InterruptHandlers, 0, sizeof(s_x86InterruptHandlers));
+  memset(&s_x86_interrupt_handlers, 0, sizeof(s_x86_interrupt_handlers));
 }
 
 StatusCode x86_interrupt_register_handler(x86InterruptHandler handler, uint8_t *handler_id) {
@@ -85,7 +85,7 @@ StatusCode x86_interrupt_register_handler(x86InterruptHandler handler, uint8_t *
 
   *handler_id = s_x86_interrupt_next_handler_id;
   s_x86_interrupt_next_handler_id++;
-  s_x86InterruptHandlers[*handler_id] = handler;
+  s_x86_interrupt_handlers[*handler_id] = handler;
 
   return STATUS_CODE_OK;
 }

--- a/libraries/x86/src/x86_interrupt.c
+++ b/libraries/x86/src/x86_interrupt.c
@@ -24,7 +24,7 @@ static uint8_t s_x86_interrupt_next_interrupt_id = 0;
 static uint8_t s_x86_interrupt_next_handler_id = 0;
 
 static Interrupt s_x86_interrupt_interrupts_map[NUM_X86_INTERRUPT_INTERRUPTS];
-static x86_interrupt_handler s_x86_interrupt_handlers[NUM_X86_INTERRUPT_HANDLERS];
+static x86InterruptHandler s_x86InterruptHandlers[NUM_X86_INTERRUPT_HANDLERS];
 
 // Signal handler for all interrupts. Prioritization is handled by the implementation of signals and
 // the init function. Signals of higher priority interrupt the running of this function. All other
@@ -36,7 +36,7 @@ void prv_sig_handler(int signum, siginfo_t *info, void *ptr) {
     if (!s_x86_interrupt_interrupts_map[info->si_value.sival_int].is_event) {
       // Execute the handler passing it the interrupt ID. To determine which handler look up in
       // the interrupts map by interrupt ID.
-      s_x86_interrupt_handlers[s_x86_interrupt_interrupts_map[info->si_value.sival_int].handler_id](
+      s_x86InterruptHandlers[s_x86_interrupt_interrupts_map[info->si_value.sival_int].handler_id](
           info->si_value.sival_int);
     }
   }
@@ -75,17 +75,17 @@ void x86_interrupt_init(void) {
   s_x86_interrupt_next_handler_id = 0;
 
   memset(&s_x86_interrupt_interrupts_map, 0, sizeof(s_x86_interrupt_interrupts_map));
-  memset(&s_x86_interrupt_handlers, 0, sizeof(s_x86_interrupt_handlers));
+  memset(&s_x86InterruptHandlers, 0, sizeof(s_x86InterruptHandlers));
 }
 
-StatusCode x86_interrupt_register_handler(x86_interrupt_handler handler, uint8_t *handler_id) {
+StatusCode x86_interrupt_register_handler(x86InterruptHandler handler, uint8_t *handler_id) {
   if (s_x86_interrupt_next_handler_id >= NUM_X86_INTERRUPT_HANDLERS) {
     return status_code(STATUS_CODE_RESOURCE_EXHAUSTED);
   }
 
   *handler_id = s_x86_interrupt_next_handler_id;
   s_x86_interrupt_next_handler_id++;
-  s_x86_interrupt_handlers[*handler_id] = handler;
+  s_x86InterruptHandlers[*handler_id] = handler;
 
   return STATUS_CODE_OK;
 }


### PR DESCRIPTION
Unifies the callback declaration style across libraries and projects that we own to be CamelCase.

This was done using the following method:

Find the type definitions using:
```bash
$ rg 'typedef .* ('
```
[rg](https://github.com/BurntSushi/ripgrep)

Fix using `sed` to (don't run in directory with `.git` or it will corrupt the log):
```bash
$ find . -type -exec sed -i 's/<before>/<after>/g' {} +
```

For now acronyms will remain the `UPPERCASE` style until that can be hopefully fixed with `clang-rename`.

