### PR TITLE
ELEC-128: Roll codegen-tooling forward to latest (v0.0.6)

### DIFF
--- a/libraries/codegen-tooling/inc/can_pack.h
+++ b/libraries/codegen-tooling/inc/can_pack.h
@@ -48,10 +48,11 @@
                     SYSTEM_CAN_MESSAGE_MC_ERROR_LIMITS, 4, (error_id_u16), (limits_u16), \
                     CAN_PACK_IMPL_EMPTY, CAN_PACK_IMPL_EMPTY)
 
-#define CAN_PACK_MOTOR_CONTROLS(msg_ptr, throttle_u16, steering_angle_u16)                      \
-  can_pack_impl_u16((msg_ptr), SYSTEM_CAN_DEVICE_DRIVER_CONTROLS,                               \
-                    SYSTEM_CAN_MESSAGE_MOTOR_CONTROLS, 4, (throttle_u16), (steering_angle_u16), \
-                    CAN_PACK_IMPL_EMPTY, CAN_PACK_IMPL_EMPTY)
+#define CAN_PACK_MOTOR_CONTROLS(msg_ptr, throttle_u16, direction_u16, cruise_control_u16,  \
+                                steering_angle_u16)                                        \
+  can_pack_impl_u16((msg_ptr), SYSTEM_CAN_DEVICE_DRIVER_CONTROLS,                          \
+                    SYSTEM_CAN_MESSAGE_MOTOR_CONTROLS, 8, (throttle_u16), (direction_u16), \
+                    (cruise_control_u16), (steering_angle_u16))
 
 #define CAN_PACK_LIGHTS_STATES(msg_ptr, light_id_u8, light_state_u8)                               \
   can_pack_impl_u8((msg_ptr), SYSTEM_CAN_DEVICE_DRIVER_CONTROLS, SYSTEM_CAN_MESSAGE_LIGHTS_STATES, \

--- a/libraries/codegen-tooling/inc/can_transmit.h
+++ b/libraries/codegen-tooling/inc/can_transmit.h
@@ -73,12 +73,14 @@
     status;                                                       \
   })
 
-#define CAN_TRANSMIT_MOTOR_CONTROLS(throttle_u16, steering_angle_u16)    \
-  ({                                                                     \
-    CANMessage msg = { 0 };                                              \
-    CAN_PACK_MOTOR_CONTROLS(&msg, (throttle_u16), (steering_angle_u16)); \
-    StatusCode status = can_transmit(&msg, NULL);                        \
-    status;                                                              \
+#define CAN_TRANSMIT_MOTOR_CONTROLS(throttle_u16, direction_u16, cruise_control_u16,     \
+                                    steering_angle_u16)                                  \
+  ({                                                                                     \
+    CANMessage msg = { 0 };                                                              \
+    CAN_PACK_MOTOR_CONTROLS(&msg, (throttle_u16), (direction_u16), (cruise_control_u16), \
+                            (steering_angle_u16));                                       \
+    StatusCode status = can_transmit(&msg, NULL);                                        \
+    status;                                                                              \
   })
 
 #define CAN_TRANSMIT_LIGHTS_STATES(light_id_u8, light_state_u8)    \

--- a/libraries/codegen-tooling/inc/can_unpack.h
+++ b/libraries/codegen-tooling/inc/can_unpack.h
@@ -40,9 +40,10 @@
   can_unpack_impl_u16((msg_ptr), 4, (error_id_u16_ptr), (limits_u16_ptr), CAN_UNPACK_IMPL_EMPTY, \
                       CAN_UNPACK_IMPL_EMPTY)
 
-#define CAN_UNPACK_MOTOR_CONTROLS(msg_ptr, throttle_u16_ptr, steering_angle_u16_ptr) \
-  can_unpack_impl_u16((msg_ptr), 4, (throttle_u16_ptr), (steering_angle_u16_ptr),    \
-                      CAN_UNPACK_IMPL_EMPTY, CAN_UNPACK_IMPL_EMPTY)
+#define CAN_UNPACK_MOTOR_CONTROLS(msg_ptr, throttle_u16_ptr, direction_u16_ptr,   \
+                                  cruise_control_u16_ptr, steering_angle_u16_ptr) \
+  can_unpack_impl_u16((msg_ptr), 8, (throttle_u16_ptr), (direction_u16_ptr),      \
+                      (cruise_control_u16_ptr), (steering_angle_u16_ptr))
 
 #define CAN_UNPACK_LIGHTS_STATES(msg_ptr, light_id_u8_ptr, light_state_u8_ptr)                     \
   can_unpack_impl_u8((msg_ptr), 2, (light_id_u8_ptr), (light_state_u8_ptr), CAN_UNPACK_IMPL_EMPTY, \

--- a/libraries/codegen-tooling/version.txt
+++ b/libraries/codegen-tooling/version.txt
@@ -1,1 +1,1 @@
-375b314195a00fd6f780bff1ec63f3311b9eb7b93d4b7688068df7d7a3ba9a5b  codegen-tooling-out.zip
+14e2679f2c44e7360ac3a4f524128c0617b21aac27ab85d078f5cba35382a20e  codegen-tooling-out.zip

--- a/make/git_fetch.py
+++ b/make/git_fetch.py
@@ -50,7 +50,7 @@ def fetch_release(url, tag, output_file):
     """
     popen = subprocess.Popen(
         [
-            'curl -s {}{} | grep "{}" | cut -d : -f 2,3 |tr -d \\" | wget -qi -'.
+            'curl -A "curl" -s {}{} | grep "{}" | cut -d : -f 2,3 |tr -d \\" | wget -qi -'.
             format(url, tag, output_file)
         ],
         shell=True,


### PR DESCRIPTION
* Roll codegen-tooling forward to latest release (v0.0.6)
* Force `curl` to use `curl` User-Agent and not whatever is specified in ~/.curlrc

Not sure if we want the second change, but I was running into an issue where I had the following set in my `~/.curlrc` file

```
# Send a fake UA string for the HTTP servers that sniff it
# Pretend to be IE 9 on Windows 7
user-agent = "Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)"

# Wait 60 seconds before timing out
connect-timeout = 60

# When following a redirect, automatically set the previous URL as referer
referer = ";auto"

# Show error messages
show-error
```

And because my User-Agent string doesn't contain `curl`, GitHub seems to minify the  JSON response. I've basically fixed this by forcing the User-Agent to be `curl`, but maybe that's the wrong approach?

Here's the JSON response _without_ `curl` in the header
```
 → TITANIC@firmware (elec_128_update_codegen_tooling) $ curl -s https://api.github.com/repos/uw-midsun/codegen-tooling/releases/latest

{"url":"https://api.github.com/repos/uw-midsun/codegen-tooling/releases/9722717","assets_url":"https://api.github.com/repos/uw-midsun/codegen-tooling/releases/9722717/assets","upload_url":"https://uploads.github.com/repos/uw-midsun/codegen-tooling/releases/9722717/assets{?name,label}","html_url":"https://github.com/uw-midsun/codegen-tooling/releases/tag/v0.0.6","id":9722717,"tag_name":"v0.0.6","target_commitish":"master","name":"Fix Motor Controls message field numbering in asciipb file","draft":false,"author":{"login":"karlding","id":6836385,"avatar_url":"https://avatars2.githubusercontent.com/u/6836385?v=4","gravatar_id":"","url":"https://api.github.com/users/karlding","html_url":"https://github.com/karlding","followers_url":"https://api.github.com/users/karlding/followers","following_url":"https://api.github.com/users/karlding/following{/other_user}","gists_url":"https://api.github.com/users/karlding/gists{/gist_id}","starred_url":"https://api.github.com/users/karlding/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/karlding/subscriptions","organizations_url":"https://api.github.com/users/karlding/orgs","repos_url":"https://api.github.com/users/karlding/repos","events_url":"https://api.github.com/users/karlding/events{/privacy}","received_events_url":"https://api.github.com/users/karlding/received_events","type":"User","site_admin":false},"prerelease":false,"created_at":"2018-02-18T03:04:15Z","published_at":"2018-02-18T03:08:10Z","assets":[{"url":"https://api.github.com/repos/uw-midsun/codegen-tooling/releases/assets/6246507","id":6246507,"name":"codegen-tooling-out.zip","label":null,"uploader":{"login":"karlding","id":6836385,"avatar_url":"https://avatars2.githubusercontent.com/u/6836385?v=4","gravatar_id":"","url":"https://api.github.com/users/karlding","html_url":"https://github.com/karlding","followers_url":"https://api.github.com/users/karlding/followers","following_url":"https://api.github.com/users/karlding/following{/other_user}","gists_url":"https://api.github.com/users/karlding/gists{/gist_id}","starred_url":"https://api.github.com/users/karlding/starred{/owner}{/repo}","subscriptions_url":"https://api.github.com/users/karlding/subscriptions","organizations_url":"https://api.github.com/users/karlding/orgs","repos_url":"https://api.github.com/users/karlding/repos","events_url":"https://api.github.com/users/karlding/events{/privacy}","received_events_url":"https://api.github.com/users/karlding/received_events","type":"User","site_admin":false},"content_type":"application/zip","state":"uploaded","size":5896,"download_count":18,"created_at":"2018-02-18T03:13:01Z","updated_at":"2018-02-18T03:13:02Z","browser_download_url":"https://github.com/uw-midsun/codegen-tooling/releases/download/v0.0.6/codegen-tooling-out.zip"}],"tarball_url":"https://api.github.com/repos/uw-midsun/codegen-tooling/tarball/v0.0.6","zipball_url":"https://api.github.com/repos/uw-midsun/codegen-tooling/zipball/v0.0.6","body":""}
```

Here's the JSON response when adding `curl` to the header
```
 → TITANIC@firmware (elec_128_update_codegen_tooling) $ curl -A 'curl' -s https://api.github.com/repos/uw-midsun/codegen-tooling/releases/latest

{
  "url": "https://api.github.com/repos/uw-midsun/codegen-tooling/releases/9722717",
  "assets_url": "https://api.github.com/repos/uw-midsun/codegen-tooling/releases/9722717/assets",
  "upload_url": "https://uploads.github.com/repos/uw-midsun/codegen-tooling/releases/9722717/assets{?name,label}",
  "html_url": "https://github.com/uw-midsun/codegen-tooling/releases/tag/v0.0.6",
  "id": 9722717,
  "tag_name": "v0.0.6",
  "target_commitish": "master",
  "name": "Fix Motor Controls message field numbering in asciipb file",
  "draft": false,
  "author": {
    "login": "karlding",
    "id": 6836385,
    "avatar_url": "https://avatars2.githubusercontent.com/u/6836385?v=4",
    "gravatar_id": "",
    "url": "https://api.github.com/users/karlding",
    "html_url": "https://github.com/karlding",
    "followers_url": "https://api.github.com/users/karlding/followers",
    "following_url": "https://api.github.com/users/karlding/following{/other_user}",
    "gists_url": "https://api.github.com/users/karlding/gists{/gist_id}",
    "starred_url": "https://api.github.com/users/karlding/starred{/owner}{/repo}",
    "subscriptions_url": "https://api.github.com/users/karlding/subscriptions",
    "organizations_url": "https://api.github.com/users/karlding/orgs",
    "repos_url": "https://api.github.com/users/karlding/repos",
    "events_url": "https://api.github.com/users/karlding/events{/privacy}",
    "received_events_url": "https://api.github.com/users/karlding/received_events",
    "type": "User",
    "site_admin": false
  },
  "prerelease": false,
  "created_at": "2018-02-18T03:04:15Z",
  "published_at": "2018-02-18T03:08:10Z",
  "assets": [
    {
      "url": "https://api.github.com/repos/uw-midsun/codegen-tooling/releases/assets/6246507",
      "id": 6246507,
      "name": "codegen-tooling-out.zip",
      "label": null,
      "uploader": {
        "login": "karlding",
        "id": 6836385,
        "avatar_url": "https://avatars2.githubusercontent.com/u/6836385?v=4",
        "gravatar_id": "",
        "url": "https://api.github.com/users/karlding",
        "html_url": "https://github.com/karlding",
        "followers_url": "https://api.github.com/users/karlding/followers",
        "following_url": "https://api.github.com/users/karlding/following{/other_user}",
        "gists_url": "https://api.github.com/users/karlding/gists{/gist_id}",
        "starred_url": "https://api.github.com/users/karlding/starred{/owner}{/repo}",
        "subscriptions_url": "https://api.github.com/users/karlding/subscriptions",
        "organizations_url": "https://api.github.com/users/karlding/orgs",
        "repos_url": "https://api.github.com/users/karlding/repos",
        "events_url": "https://api.github.com/users/karlding/events{/privacy}",
        "received_events_url": "https://api.github.com/users/karlding/received_events",
        "type": "User",
        "site_admin": false
      },
      "content_type": "application/zip",
      "state": "uploaded",
      "size": 5896,
      "download_count": 18,
      "created_at": "2018-02-18T03:13:01Z",
      "updated_at": "2018-02-18T03:13:02Z",
      "browser_download_url": "https://github.com/uw-midsun/codegen-tooling/releases/download/v0.0.6/codegen-tooling-out.zip"
    }
  ],
  "tarball_url": "https://api.github.com/repos/uw-midsun/codegen-tooling/tarball/v0.0.6",
  "zipball_url": "https://api.github.com/repos/uw-midsun/codegen-tooling/zipball/v0.0.6",
  "body": ""
}
```

Edit: You can probably change the `curl` and `grep` chain to be something like this

```bash
curl -s https://api.github.com/repos/uw-midsun/codegen-tooling/releases/latest | grep -Eo '"browser_download_url"\:.*codegen-tooling-out.zip"' | grep -Eo 'https://.*\.zip'
```

and then pipe that into `wget`