### PR TITLE
ELEC-40: Disable Derive Pointer Alignment and Reformat all Files

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -63,7 +63,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: false
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]

--- a/libraries/libcore/src/status.c
+++ b/libraries/libcore/src/status.c
@@ -9,8 +9,8 @@ static Status s_global_status = {
 };
 static StatusCallback s_callback;
 
-StatusCode status_impl_update(const StatusCode code, const char* source, const char* caller,
-                              const char* message) {
+StatusCode status_impl_update(const StatusCode code, const char *source, const char *caller,
+                              const char *message) {
   s_global_status.code = code;
   s_global_status.source = source;
   s_global_status.caller = caller;

--- a/libraries/ms-common/inc/soft_timer.h
+++ b/libraries/ms-common/inc/soft_timer.h
@@ -11,7 +11,7 @@
 
 typedef uint16_t SoftTimerID;
 
-typedef void (*SoftTimerCallback)(SoftTimerID timer_id, void* context);
+typedef void (*SoftTimerCallback)(SoftTimerID timer_id, void *context);
 
 // Initializes a set of software timers. Clock speed should be in MHz. Subsequent calls will do
 // nothing. The clock speed is that of the external PLL crystal.
@@ -20,8 +20,8 @@ void soft_timer_init(void);
 // Adds a software timer. The provided duration is the number of microseconds before running and the
 // callback is the process to run once the time has expired. The timer_id is set to the id of the
 // timer that will run the callback.
-StatusCode soft_timer_start(uint32_t duration_us, SoftTimerCallback callback, void* context,
-                            SoftTimerID* timer_id);
+StatusCode soft_timer_start(uint32_t duration_us, SoftTimerCallback callback, void *context,
+                            SoftTimerID *timer_id);
 
 // Starts a software timer in milliseconds. Max duration is still UINT32_MAX us.
 #define soft_timer_start_millis(duration_ms, callback, context, timer_id) \

--- a/libraries/ms-common/test/test_gpio_it.c
+++ b/libraries/ms-common/test/test_gpio_it.c
@@ -24,7 +24,7 @@ static InterruptSettings s_event_settings = {
 static volatile bool s_correct_port = false;
 static volatile bool s_interrupt_ran = false;
 
-static void prv_test_callback(const GPIOAddress* address, void* context) {
+static void prv_test_callback(const GPIOAddress *address, void *context) {
   if (address->port == 1) {
     s_correct_port = true;
   }

--- a/libraries/stm32f0xx/inc/stm32f0xx_conf.h
+++ b/libraries/stm32f0xx/inc/stm32f0xx_conf.h
@@ -73,9 +73,9 @@
  *         that failed. If expr is true, it returns no value.
  * @retval None
  */
-#define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t*)__FILE__, __LINE__))
+#define assert_param(expr) ((expr) ? (void)0 : assert_failed((uint8_t *)__FILE__, __LINE__))
 /* Exported functions ------------------------------------------------------- */
-void assert_failed(uint8_t* file, uint32_t line);
+void assert_failed(uint8_t *file, uint32_t line);
 #else
 #define assert_param(expr) ((void)0)
 #endif /* USE_FULL_ASSERT */

--- a/libraries/x86/inc/x86_interrupt.h
+++ b/libraries/x86/inc/x86_interrupt.h
@@ -13,11 +13,11 @@ void x86_interrupt_init(void);
 
 // Registers an ISR handler. The handler_id is updated to the id assigned to the handler if
 // registered successfully.
-StatusCode x86_interrupt_register_handler(x86InterruptHandler handler, uint8_t* handler_id);
+StatusCode x86_interrupt_register_handler(x86InterruptHandler handler, uint8_t *handler_id);
 
 // Registers a callback to a handler assigning it a new id from the global interrupt id pool.
-StatusCode x86_interrupt_register_interrupt(uint8_t handler_id, const InterruptSettings* settings,
-                                            uint8_t* interrupt_id);
+StatusCode x86_interrupt_register_interrupt(uint8_t handler_id, const InterruptSettings *settings,
+                                            uint8_t *interrupt_id);
 
 // Triggers a software interrupt by interrupt_id.
 StatusCode x86_interrupt_trigger(uint8_t interrupt_id);

--- a/projects/adc_driver/src/main.c
+++ b/projects/adc_driver/src/main.c
@@ -7,8 +7,8 @@
 #include "interrupt.h"
 #include "log.h"
 
-void test_callback(ADCChannel adc_channel, void* context) {
-  uint16_t* adc_reading = (uint16_t*)context;
+void test_callback(ADCChannel adc_channel, void *context) {
+  uint16_t *adc_reading = (uint16_t *)context;
   adc_read_converted(adc_channel, adc_reading);
 }
 


### PR DESCRIPTION
`DerivePointerAlignment: false` so that we use right aligned pointer always.