### PR TITLE
Elec 346 x86 uart

### DIFF
--- a/libraries/ms-common/inc/uart.h
+++ b/libraries/ms-common/inc/uart.h
@@ -3,13 +3,21 @@
 // Requires GPIO and interrupts to be initialized.
 
 // Uses internal FIFOs to buffer RX and TX.
+#include <fcntl.h>
 #include <stdint.h>
+#include <string.h>
+#include <termios.h>
+#include <unistd.h>
 #include "fifo.h"
 #include "gpio.h"
+#include "log.h"
 #include "status.h"
 #include "uart_mcu.h"
 
 #define UART_MAX_BUFFER_LEN 256
+
+// baudrate definition in termios.h
+#define BAUDRATE B38400
 
 typedef void (*UARTRxHandler)(const uint8_t *rx_arr, size_t len, void *context);
 
@@ -34,7 +42,8 @@ typedef struct {
 } UARTSettings;
 
 // Assumes standard 8 N 1
-// Registers a handler to be called when a newline is encountered or the buffer is full.
+// Registers a handler to be called when a newline is encountered or the buffer
+// is full.
 // Storage should be persistent through the program.
 StatusCode uart_init(UARTPort uart, UARTSettings *settings, UARTStorage *storage);
 
@@ -43,3 +52,9 @@ StatusCode uart_set_rx_handler(UARTPort uart, UARTRxHandler rx_handler, void *co
 
 // Non-blocking TX
 StatusCode uart_tx(UARTPort uart, uint8_t *tx_data, size_t len);
+
+// Pops from TX Fifo and sends to serial device
+void prv_tx_pop(UARTPort uart);
+
+// Reads from serial device and pushes to RX Fifo
+void prv_rx_push(UARTPort uart);

--- a/libraries/ms-common/src/x86/uart.c
+++ b/libraries/ms-common/src/x86/uart.c
@@ -1,13 +1,132 @@
 #include "uart.h"
 
+// basic idea: tx is stored in a buffer, interrupt-driven
+// rx is buffered, once a newline is hit or the buffer is full, call rx_handler
+
+typedef struct {
+  int fd;
+  int res;
+  char *port;
+  struct termios oldtio;
+  struct termios newtio;
+  UARTStorage *storage;
+} UARTPortData;
+
+// /dev/tnt0 and /dev/tnt1 are the connected virtual ports
+static UARTPortData s_port[] = {
+      [UART_PORT_1] = {.port = "/dev/tnt0" }, [UART_PORT_2] = {.port = "/dev/tnt1" },
+};
+
 StatusCode uart_init(UARTPort uart, UARTSettings *settings, UARTStorage *storage) {
-  return status_code(STATUS_CODE_UNIMPLEMENTED);
+  s_port[uart].fd = open(s_port[uart].port, O_RDWR | O_NOCTTY);
+
+  // save current serial port settings
+  tcgetattr(s_port[uart].fd, &s_port[uart].oldtio);
+  // clear struct for new port settings
+  memset(&s_port[uart].newtio, 0, sizeof(s_port[uart].newtio));
+
+  // set baudrate, hardware flow control, 8n1, local connection, enable
+  // receiving characters
+  s_port[uart].newtio.c_cflag = BAUDRATE | CRTSCTS | CS8 | CLOCAL | CREAD;
+
+  // ignore bytes with parity errors
+  // change CR to NL for eol
+  s_port[uart].newtio.c_iflag = IGNPAR | ICRNL;
+
+  // raw output
+  s_port[uart].newtio.c_oflag = 0;
+
+  // enable cannonical input
+  s_port[uart].newtio.c_lflag = ICANON;
+
+  // initialize all contorl characters
+  s_port[uart].newtio.c_cc[VINTR] = 0;     // Ctrl-c
+  s_port[uart].newtio.c_cc[VQUIT] = 0;     // Ctrl-\ //
+  s_port[uart].newtio.c_cc[VERASE] = 0;    // del
+  s_port[uart].newtio.c_cc[VKILL] = 0;     // @
+  s_port[uart].newtio.c_cc[VEOF] = 4;      // Ctrl-d
+  s_port[uart].newtio.c_cc[VTIME] = 0;     // inter-character timer unused
+  s_port[uart].newtio.c_cc[VMIN] = 1;      // blocking read until 1 character arrives
+  s_port[uart].newtio.c_cc[VSWTC] = 0;     // '\0'
+  s_port[uart].newtio.c_cc[VSTART] = 0;    // Ctrl-q
+  s_port[uart].newtio.c_cc[VSTOP] = 0;     // Ctrl-s
+  s_port[uart].newtio.c_cc[VSUSP] = 0;     // Ctrl-z
+  s_port[uart].newtio.c_cc[VEOL] = 0;      // '\0'
+  s_port[uart].newtio.c_cc[VREPRINT] = 0;  // Ctrl-r
+  s_port[uart].newtio.c_cc[VDISCARD] = 0;  // Ctrl-u
+  s_port[uart].newtio.c_cc[VWERASE] = 0;   // Ctrl-w
+  s_port[uart].newtio.c_cc[VLNEXT] = 0;    // Ctrl-v
+  s_port[uart].newtio.c_cc[VEOL2] = 0;     // '\0'
+
+  // clean modem line and activate settings
+  tcflush(s_port[uart].fd, TCIFLUSH);
+  tcsetattr(s_port[uart].fd, TCSANOW, &s_port[uart].newtio);
+
+  s_port[uart].storage = storage;
+  memset(storage, 0, sizeof(*storage));
+
+  s_port[uart].storage->rx_handler = settings->rx_handler;
+  s_port[uart].storage->context = settings->context;
+  fifo_init(&s_port[uart].storage->tx_fifo, s_port[uart].storage->tx_buf);
+  fifo_init(&s_port[uart].storage->rx_fifo, s_port[uart].storage->rx_buf);
+
+  return STATUS_CODE_OK;
 }
 
 StatusCode uart_set_rx_handler(UARTPort uart, UARTRxHandler rx_handler, void *context) {
-  return status_code(STATUS_CODE_UNIMPLEMENTED);
+  s_port[uart].storage->rx_handler = rx_handler;
+  s_port[uart].storage->context = context;
+
+  return STATUS_CODE_OK;
 }
 
 StatusCode uart_tx(UARTPort uart, uint8_t *tx_data, size_t len) {
-  return status_code(STATUS_CODE_UNIMPLEMENTED);
+  status_ok_or_return(fifo_push_arr(&s_port[uart].storage->tx_fifo, tx_data, len));
+  prv_tx_pop(uart);
+
+  return STATUS_CODE_OK;
+}
+
+void prv_tx_pop(UARTPort uart) {
+  if (fifo_size(&s_port[uart].storage->tx_fifo) != 0) {
+    int res;
+    size_t num_bytes = fifo_size(&s_port[uart].storage->tx_fifo);
+    uint8_t tx_data[num_bytes];
+
+    fifo_pop_arr(&s_port[uart].storage->tx_fifo, tx_data, num_bytes);
+
+    // send the string
+    res = write(s_port[uart].fd, tx_data, num_bytes);
+
+    // ensure a terminating character is subsequent
+    if (tx_data[0] != '\n') {
+      res = write(s_port[uart].fd, "\n", 1);
+    }
+
+    if (res < 0) {
+      LOG_DEBUG("Could not send to serial port.");
+    }
+  }
+}
+
+void prv_rx_push(UARTPort uart) {
+  int res;
+  uint8_t rx_data;
+  res = read(s_port[uart].fd, &rx_data, 1);
+  fifo_push(&s_port[uart].storage->rx_fifo, &rx_data);
+
+  size_t num_bytes = fifo_size(&s_port[uart].storage->rx_fifo);
+
+  if (rx_data == '\n' || num_bytes == UART_MAX_BUFFER_LEN) {
+    uint8_t buf[UART_MAX_BUFFER_LEN + 1] = { 0 };
+    fifo_pop_arr(&s_port[uart].storage->rx_fifo, buf, num_bytes);
+
+    if (s_port[uart].storage->rx_handler != NULL) {
+      s_port[uart].storage->rx_handler(buf, num_bytes, s_port[uart].storage->context);
+    }
+  }
+
+  if (res < 0) {
+    LOG_DEBUG("Could not read from serial port.");
+  }
 }

--- a/libraries/ms-common/src/x86/uart.c
+++ b/libraries/ms-common/src/x86/uart.c
@@ -2,6 +2,9 @@
 
 // basic idea: tx is stored in a buffer, interrupt-driven
 // rx is buffered, once a newline is hit or the buffer is full, call rx_handler
+// requires tty0tty to be installed
+// sudo depmod && sudo modprobe tty0tty && sudo chmod 666 /dev/tnt*
+// must be run each time vagrant is started
 
 typedef struct {
   int fd;
@@ -19,6 +22,9 @@ static UARTPortData s_port[] = {
 
 StatusCode uart_init(UARTPort uart, UARTSettings *settings, UARTStorage *storage) {
   s_port[uart].fd = open(s_port[uart].port, O_RDWR | O_NOCTTY);
+  if (fd < 0) {
+    LOG_DEBUG("Null modem emulator tty0tty may not be installed or initialized properly.")
+  }
 
   // save current serial port settings
   tcgetattr(s_port[uart].fd, &s_port[uart].oldtio);

--- a/projects/uart_test/src/main.c
+++ b/projects/uart_test/src/main.c
@@ -1,0 +1,66 @@
+// x86 UART initiate receiver and transmitter
+#include <stdio.h>
+#include "log.h"
+#include "uart.h"
+
+void receiver_handler(const uint8_t *rx_arr, size_t len, void *context) {
+  char arr[len];
+  // print out the received output
+  for (int i = 0; i < (int)len; i++) {
+    arr[i] = (char)*(rx_arr + (uint8_t)i);
+  }
+  LOG_DEBUG("%s\n", arr);
+}
+
+int main(void) {
+  // Start of Setup
+
+  // create settings for the UART device - npte: not alt fn on x86
+  UARTSettings settings = {
+    .baudrate = 115200, .rx_handler = receiver_handler, .context = 0, .alt_fn = GPIO_ALTFN_NONE
+  };
+
+  // declare a fifo input and a fifo output buffer
+  uint8_t transfer[UART_MAX_BUFFER_LEN] = { 0 };
+  uint8_t receiver[UART_MAX_BUFFER_LEN] = { 0 };
+
+  Fifo tx_fifo = {
+    .buffer = transfer,
+    .end = (transfer + 255),
+    .head = transfer,
+    .next = (transfer + 1),
+    .num_elems = 0,
+    .max_elems = UART_MAX_BUFFER_LEN,
+    .elem_size = 1,
+  };
+
+  Fifo rx_fifo = {
+    .buffer = receiver,
+    .end = (receiver + 255),
+    .head = receiver,
+    .next = (receiver + 1),
+    .num_elems = 0,
+    .max_elems = UART_MAX_BUFFER_LEN,
+    .elem_size = 1,
+  };
+
+  // create storage struct for the uart device
+  UARTStorage storage = {
+    .rx_handler = receiver_handler, .context = 0, .tx_fifo = tx_fifo, .rx_fifo = rx_fifo
+  };
+
+  LOG_DEBUG("UART Init Status: %d\n", uart_init(UART_PORT_1, &settings, &storage));
+
+  // End of Setup
+
+  // load a string
+  uint8_t send[14] = "Hello, World!\n";
+  uart_tx(UART_PORT_1, send, 14);
+
+  // receive bytes from tnt1
+  while (1) {
+    prv_rx_push(UART_PORT_1);
+  }
+
+  return 0;
+}

--- a/projects/uart_test/test/tnt0.c
+++ b/projects/uart_test/test/tnt0.c
@@ -1,0 +1,123 @@
+// send and receive functionality on port tnt0
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <termios.h>
+
+/* baudrate settings are defined in <asm/termbits.h>, which is
+included by <termios.h> */
+#define BAUDRATE B38400
+/* change this definition for the correct port */
+#define MODEMDEVICE "/dev/tnt0"
+#define _POSIX_SOURCE 1 /* POSIX compliant source */
+
+#define FALSE 0
+#define TRUE 1
+
+volatile int STOP = FALSE;
+
+int main() {
+  int fd, res, c;
+  char buf[255];
+  char input[255];
+  struct termios oldtio, newtio;
+
+  /*
+    Open modem device for reading and writing and not as controlling tty
+    because we don't want to get killed if linenoise sends CTRL-C.
+  */
+  fd = open(MODEMDEVICE, O_RDWR | O_NOCTTY);
+  if (fd < 0) {
+    perror(MODEMDEVICE);
+    exit(-1);
+  }
+
+  tcgetattr(fd, &oldtio);         /* save current serial port settings */
+  bzero(&newtio, sizeof(newtio)); /* clear struct for new port settings */
+
+  /*
+    BAUDRATE: Set bps rate. You could also use cfsetispeed and cfsetospeed.
+    CRTSCTS : output hardware flow control (only used if the cable has
+              all necessary lines. See sect. 7 of Serial-HOWTO)
+    CS8     : 8n1 (8bit,no parity,1 stopbit)
+    CLOCAL  : local connection, no modem contol
+    CREAD   : enable receiving characters
+  */
+  newtio.c_cflag = BAUDRATE | CRTSCTS | CS8 | CLOCAL | CREAD;
+
+  /*
+    IGNPAR  : ignore bytes with parity errors
+    ICRNL   : map CR to NL (otherwise a CR input on the other computer
+              will not terminate input)
+    otherwise make device raw (no other input processing)
+  */
+  newtio.c_iflag = IGNPAR | ICRNL;
+
+  /*
+   Raw output.
+  */
+  newtio.c_oflag = 0;
+
+  /*
+    ICANON  : enable canonical input
+    disable all echo functionality, and don't send signals to calling program
+  */
+  newtio.c_lflag = ICANON;
+
+  /*
+    initialize all control characters
+    default values can be found in /usr/include/termios.h, and are given
+    in the comments, but we don't need them here
+  */
+  newtio.c_cc[VINTR] = 0;    /* Ctrl-c */
+  newtio.c_cc[VQUIT] = 0;    /* Ctrl-\ */
+  newtio.c_cc[VERASE] = 0;   /* del */
+  newtio.c_cc[VKILL] = 0;    /* @ */
+  newtio.c_cc[VEOF] = 4;     /* Ctrl-d */
+  newtio.c_cc[VTIME] = 0;    /* inter-character timer unused */
+  newtio.c_cc[VMIN] = 1;     /* blocking read until 1 character arrives */
+  newtio.c_cc[VSWTC] = 0;    /* '\0' */
+  newtio.c_cc[VSTART] = 0;   /* Ctrl-q */
+  newtio.c_cc[VSTOP] = 0;    /* Ctrl-s */
+  newtio.c_cc[VSUSP] = 0;    /* Ctrl-z */
+  newtio.c_cc[VEOL] = 0;     /* '\0' */
+  newtio.c_cc[VREPRINT] = 0; /* Ctrl-r */
+  newtio.c_cc[VDISCARD] = 0; /* Ctrl-u */
+  newtio.c_cc[VWERASE] = 0;  /* Ctrl-w */
+  newtio.c_cc[VLNEXT] = 0;   /* Ctrl-v */
+  newtio.c_cc[VEOL2] = 0;    /* '\0' */
+
+  /*
+    now clean the modem line and activate the settings for the port
+  */
+  tcflush(fd, TCIFLUSH);
+  tcsetattr(fd, TCSANOW, &newtio);
+
+  while (!STOP) {
+    c = getchar();
+
+    if (c == 'w') {
+      // write to tnt1
+      res = write(fd,
+                  "Lorem ipsum dolor sit amet, nonummy ligula volutpat hac integer nonummy. \
+      Suspendisse ultricies, congue etiam tellus, erat libero, nulla eleifend, mauris pellentesque.\
+      Suspendisse integer praesent vel, integer gravida mauris, fringilla vehicula lacinia non\n",
+                  256);
+      printf("Result: %d\n", res);
+    }
+    if (c == 'r') {
+      // read from tnt1
+      res = read(fd, buf, 200);
+      buf[res] = 0;  // set end of string, so we can printf
+      printf("%s%d\n", buf, res);
+      printf("%d\n", res);
+      if (buf[0] == 'z') STOP = TRUE;
+    }
+  }
+
+  /* restore the old port settings */
+  tcsetattr(fd, TCSANOW, &oldtio);
+
+  return 0;
+}

--- a/projects/uart_test/test/tnt1.c
+++ b/projects/uart_test/test/tnt1.c
@@ -1,0 +1,119 @@
+// send and receive functionality on port tnt1
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <termios.h>
+
+/* baudrate settings are defined in <asm/termbits.h>, which is
+included by <termios.h> */
+#define BAUDRATE B38400
+/* change this definition for the correct port */
+#define MODEMDEVICE "/dev/tnt1"
+#define _POSIX_SOURCE 1 /* POSIX compliant source */
+
+#define FALSE 0
+#define TRUE 1
+
+volatile int STOP = FALSE;
+
+int main() {
+  int fd, res, c;
+  int newline = 10;
+  char buf[255];
+  char input[255];
+  struct termios oldtio, newtio;
+
+  /*
+    Open modem device for reading and writing and not as controlling tty
+    because we don't want to get killed if linenoise sends CTRL-C.
+  */
+  fd = open(MODEMDEVICE, O_RDWR | O_NOCTTY);
+  if (fd < 0) {
+    perror(MODEMDEVICE);
+    exit(-1);
+  }
+
+  tcgetattr(fd, &oldtio);         /* save current serial port settings */
+  bzero(&newtio, sizeof(newtio)); /* clear struct for new port settings */
+
+  /*
+    BAUDRATE: Set bps rate. You could also use cfsetispeed and cfsetospeed.
+    CRTSCTS : output hardware flow control (only used if the cable has
+              all necessary lines. See sect. 7 of Serial-HOWTO)
+    CS8     : 8n1 (8bit,no parity,1 stopbit)
+    CLOCAL  : local connection, no modem contol
+    CREAD   : enable receiving characters
+  */
+  newtio.c_cflag = BAUDRATE | CRTSCTS | CS8 | CLOCAL | CREAD;
+
+  /*
+    IGNPAR  : ignore bytes with parity errors
+    ICRNL   : map CR to NL (otherwise a CR input on the other computer
+              will not terminate input)
+    otherwise make device raw (no other input processing)
+  */
+  newtio.c_iflag = IGNPAR | ICRNL;
+
+  /*
+   Raw output.
+  */
+  newtio.c_oflag = 0;
+
+  /*
+    ICANON  : enable canonical input
+    disable all echo functionality, and don't send signals to calling program
+  */
+  newtio.c_lflag = ICANON;
+
+  /*
+    initialize all control characters
+    default values can be found in /usr/include/termios.h, and are given
+    in the comments, but we don't need them here
+  */
+  newtio.c_cc[VINTR] = 0;    /* Ctrl-c */
+  newtio.c_cc[VQUIT] = 0;    /* Ctrl-\ */
+  newtio.c_cc[VERASE] = 0;   /* del */
+  newtio.c_cc[VKILL] = 0;    /* @ */
+  newtio.c_cc[VEOF] = 4;     /* Ctrl-d */
+  newtio.c_cc[VTIME] = 0;    /* inter-character timer unused */
+  newtio.c_cc[VMIN] = 1;     /* blocking read until 1 character arrives */
+  newtio.c_cc[VSWTC] = 0;    /* '\0' */
+  newtio.c_cc[VSTART] = 0;   /* Ctrl-q */
+  newtio.c_cc[VSTOP] = 0;    /* Ctrl-s */
+  newtio.c_cc[VSUSP] = 0;    /* Ctrl-z */
+  newtio.c_cc[VEOL] = 0;     /* '\0' */
+  newtio.c_cc[VREPRINT] = 0; /* Ctrl-r */
+  newtio.c_cc[VDISCARD] = 0; /* Ctrl-u */
+  newtio.c_cc[VWERASE] = 0;  /* Ctrl-w */
+  newtio.c_cc[VLNEXT] = 0;   /* Ctrl-v */
+  newtio.c_cc[VEOL2] = 0;    /* '\0' */
+
+  /*
+    now clean the modem line and activate the settings for the port
+  */
+  tcflush(fd, TCIFLUSH);
+  tcsetattr(fd, TCSANOW, &newtio);
+
+  while (!STOP) {
+    c = getchar();
+
+    if (c == 'w') {
+      // write to tnt0
+      res = write(fd, "Lorem \n", 7);
+      printf("Result: %d\n", res);
+    }
+    if (c == 'r') {
+      // read from tnt0
+      res = read(fd, buf, 200);
+      buf[res] = 0;  // set end of string, so we can printf
+      printf("%s%d\n", buf, res);
+      if (buf[0] == 'z') STOP = TRUE;
+    }
+  }
+
+  /* restore the old port settings */
+  tcsetattr(fd, TCSANOW, &oldtio);
+
+  return 0;
+}


### PR DESCRIPTION
Only the two files mentioned below need to be merged. There are brief comments in the x86 uart.c file which identify the null modem emulator (tty0tty) needed to create the virtual serial ports and the necessary commands to run on startup of vagrant. Let me know if a more comprehensive readme file is needed. tty0tty can be cloned from: https://github.com/freemed/tty0tty

libraries/ms-common/src/x86/uart.c
libraries/ms-common/inc/uart.h
