### PR TITLE
ELEC-378: Support mocking in tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,6 +66,7 @@ GDB_TARGET = $(BIN_DIR)/test/$(LIBRARY)$(PROJECT)/test_$(TEST)_runner$(PLATFORM_
 endif
 
 DIRS := $(BUILD_DIR) $(BIN_DIR) $(STATIC_LIB_DIR) $(OBJ_CACHE)
+COMMA := ,
 
 # Please don't touch anything below this line
 ###################################################################################################

--- a/libraries/libcore/inc/test_helpers.h
+++ b/libraries/libcore/inc/test_helpers.h
@@ -7,3 +7,6 @@
 // General use:
 #define TEST_ASSERT_OK(code) TEST_ASSERT_EQUAL(STATUS_CODE_OK, (code))
 #define TEST_ASSERT_NOT_OK(code) TEST_ASSERT_NOT_EQUAL(STATUS_CODE_OK, (code))
+
+// Mocking
+#define TEST_MOCK(func) __wrap_##func

--- a/libraries/libcore/rules.mk
+++ b/libraries/libcore/rules.mk
@@ -5,4 +5,6 @@
 # $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
 # $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
 
-$(T)_DEPS := 
+$(T)_DEPS :=
+
+$(T)_test_mock_MOCKS := status_impl_update

--- a/libraries/libcore/test/test_mock.c
+++ b/libraries/libcore/test/test_mock.c
@@ -1,7 +1,7 @@
-#include "unity.h"
-#include "test_helpers.h"
 #include "log.h"
 #include "status.h"
+#include "test_helpers.h"
+#include "unity.h"
 
 // Example of a mock - add function name to $(T)_test_[name]_MOCKS to override behavior
 
@@ -12,11 +12,9 @@ StatusCode TEST_MOCK(status_impl_update)(StatusCode code, const char *source, co
   return STATUS_CODE_OK;
 }
 
-void setup_test(void) {
-}
+void setup_test(void) {}
 
-void teardown_test(void) {
-}
+void teardown_test(void) {}
 
 void test_mock_usage(void) {
   status_msg(STATUS_CODE_INTERNAL_ERROR, "this is a message\n");

--- a/libraries/libcore/test/test_mock.c
+++ b/libraries/libcore/test/test_mock.c
@@ -1,0 +1,23 @@
+#include "unity.h"
+#include "test_helpers.h"
+#include "log.h"
+#include "status.h"
+
+// Example of a mock - add function name to $(T)_test_[name]_MOCKS to override behavior
+
+StatusCode TEST_MOCK(status_impl_update)(StatusCode code, const char *source, const char *caller,
+                                         const char *message) {
+  LOG_DEBUG("Mock: code %d\nsrc: %s\ncaller: %s\nmsg: %s\n", code, source, caller, message);
+
+  return STATUS_CODE_OK;
+}
+
+void setup_test(void) {
+}
+
+void teardown_test(void) {
+}
+
+void test_mock_usage(void) {
+  status_msg(STATUS_CODE_INTERNAL_ERROR, "this is a message\n");
+}

--- a/make/build_test.mk
+++ b/make/build_test.mk
@@ -52,9 +52,10 @@ $($(T)_TESTS): $($(T)_TEST_BIN_DIR)/%_runner$(PLATFORM_EXT): \
                  $($(T)_TEST_OBJ_DIR)/%.o $($(T)_TEST_OBJ_DIR)/%_runner.o \
                  $(call dep_to_lib,$($(T)_TEST_DEPS)) | $(T) $($(T)_TEST_BIN_DIR)
 	@echo "Building test $(notdir $@) for $(PLATFORM)"
-	@$(CC) $($(firstword $|)_CFLAGS) -Wl,-Map=$(lastword $|)/$(notdir $(@:%$(PLATFORM_EXT)=%.map)) $^ -o $@ \
-		-L$(STATIC_LIB_DIR) $(addprefix -l,$(foreach lib,$($(firstword $|)_TEST_DEPS),$($(lib)_DEPS))) \
-		$(LDFLAGS) $(addprefix -I,$($(firstword $|)_INC_DIRS) $(unity_INC_DIRS))
+	@$(CC) $($(firstword $|)_CFLAGS) -Wl,-Map=$(lastword $|)/$(notdir $(@:%$(PLATFORM_EXT)=%.map)) \
+    $(addprefix -Wl$(COMMA)-wrap$(COMMA),$($(firstword $|)_$(notdir $(@:%_runner=%))_MOCKS)) $^ -o $@ \
+    -L$(STATIC_LIB_DIR) $(addprefix -l,$(foreach lib,$($(firstword $|)_TEST_DEPS),$($(lib)_DEPS))) \
+    $(LDFLAGS) $(addprefix -I,$($(firstword $|)_INC_DIRS) $(unity_INC_DIRS))
 
 .PHONY: test test_ test_$(T)
 

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -51,14 +51,15 @@ endif
 LDFLAGS := -lrt
 
 # Shell environment variables
+FLASH_VAR := MIDSUN_X86_FLASH_FILE
 ifneq (,$(filter test test_all,$(MAKECMDGOALS)))
 ifeq (,$(TEST))
-  ENV_VARS = MIDSUN_X86_FLASH_FILE=$(test)_flash
+  ENV_VARS = $(FLASH_VAR)=$(test)_flash
 else
-  ENV_VARS = MIDSUN_X86_FLASH_FILE=$<_flash
+  ENV_VARS = $(FLASH_VAR)=$<_flash
 endif
 else
-  ENV_VARS := MIDSUN_X86_FLASH_FILE=$(BIN_DIR)/$(PROJECT)$(LIBRARY)_flash
+  ENV_VARS := $(FLASH_VAR)=$(BIN_DIR)/$(PROJECT)$(LIBRARY)_flash
 endif
 
 # Platform targets

--- a/platform/x86/platform.mk
+++ b/platform/x86/platform.mk
@@ -51,9 +51,14 @@ endif
 LDFLAGS := -lrt
 
 # Shell environment variables
-ENV_VARS := MIDSUN_X86_FLASH_FILE=$(BIN_DIR)/$(PROJECT)$(LIBRARY)_flash
-ifneq (,$(TEST))
-  ENV_VARS := $(ENV_VARS)_test_$(TEST)
+ifneq (,$(filter test test_all,$(MAKECMDGOALS)))
+ifeq (,$(TEST))
+  ENV_VARS = MIDSUN_X86_FLASH_FILE=$(test)_flash
+else
+  ENV_VARS = MIDSUN_X86_FLASH_FILE=$<_flash
+endif
+else
+  ENV_VARS := MIDSUN_X86_FLASH_FILE=$(BIN_DIR)/$(PROJECT)$(LIBRARY)_flash
 endif
 
 # Platform targets


### PR DESCRIPTION
Adds support for test-specific mocking through the use of GCC's `-Wl,wrap` with an example. Also fixes x86 flash locations for `test_all`.

The idea is that `$(T)_test_[module]_MOCKS := [func names]` can be used to wrap specific functions that need to be mocked, and `TEST_MOCK` wraps the mocked function name. I wanted to add this for validating modules that depend mostly on external hardware. Mocking would allow us to inject arbitrary data and failure conditions without modifying the hardware module itself.