### PR TITLE
ELEC-40: Fix Clang -Wsign-conversion errors

### DIFF
--- a/libraries/ms-common/test/test_gpio.c
+++ b/libraries/ms-common/test/test_gpio.c
@@ -174,7 +174,7 @@ void test_gpio_set_state_invalid_state(void) {
   // A port that should be valid on all configurations.
   GPIOAddress address = { .port = VALID_PORT, .pin = VALID_PIN };
   TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, gpio_set_state(&address, NUM_GPIO_STATES));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, gpio_set_state(&address, -1));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, gpio_set_state(&address, (GPIOState)-1));
 }
 
 // gpio_toggle_state

--- a/projects/driver_controls/src/gpio_expander.c
+++ b/projects/driver_controls/src/gpio_expander.c
@@ -34,7 +34,7 @@ static void prv_interrupt_handler(const GPIOAddress *address, void *context) {
   // Identify all pins with a pending interrupt and execute their callbacks
   GPIOExpanderPin current_pin;
   while (intf != 0) {
-    current_pin = __builtin_ffs(intf) - 1;
+    current_pin = (GPIOExpanderPin)(__builtin_ffs(intf) - 1);
 
     if (s_interrupts[current_pin].callback != NULL) {
       s_interrupts[current_pin].callback(current_pin, (intcap >> current_pin) & 1,

--- a/projects/driver_controls/src/x86/ads1015.c
+++ b/projects/driver_controls/src/x86/ads1015.c
@@ -55,7 +55,7 @@ static void prv_timer_callback(SoftTimerID id, void *context) {
     storage->pending_channel_bitset = storage->channel_bitset;
   }
   // Obtain the next enabled channel.
-  current_channel = __builtin_ffs(storage->pending_channel_bitset) - 1;
+  current_channel = (Ads1015Channel)(__builtin_ffs(storage->pending_channel_bitset) - 1);
   // Update so that the ADS1015 reads from the next channel.
   prv_set_channel(storage, current_channel);
   soft_timer_start(ADS1015_CHANNEL_UPDATE_PERIOD_US, prv_timer_callback, storage, NULL);


### PR DESCRIPTION
Did a `make reallyclean` `make build_all PLATFORM=x86 COMPILER=clang` and found a few trivial cast errors that needed fixing.