### PR TITLE
ELEC-355: Controller module for Charger via CAN

### DIFF
--- a/projects/charger/inc/charger_controller.h
+++ b/projects/charger/inc/charger_controller.h
@@ -1,0 +1,66 @@
+#pragma once
+// Module for controlling the charger
+// Requires soft_timers, generic can and interrupts.
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "can_interval.h"
+#include "generic_can.h"
+
+// Defined in datasheet.
+typedef enum ChargerState {
+  CHARGER_STATE_START = 0,
+  CHARGER_STATE_STOP = 1,
+  NUM_CHARGER_STATES,
+} ChargerState;
+
+// Also defined in datasheet.
+typedef union ChargerStatus {
+  uint8_t raw;
+  struct {
+    uint8_t hw_fault : 1;
+    uint8_t over_temp : 1;
+    uint8_t input_voltage : 1;
+    uint8_t starting_state : 1;
+    uint8_t comms_state : 1;
+  };
+} ChargerStatus;
+
+typedef struct ChargerSettings {
+  uint16_t max_voltage;
+  uint16_t max_current;
+  GenericCan *can;
+  GenericCan *can_uart;
+} ChargerSettings;
+
+typedef struct ChargerControllerTxDataImpl {
+  uint16_t max_voltage;
+  uint16_t max_current;
+  uint8_t charging;
+} ChargerControllerTxDataImpl;
+
+typedef union ChargerControllerTxData {
+  uint64_t raw_data;
+  ChargerControllerTxDataImpl data_impl;
+} ChargerControllerTxData;
+
+typedef struct ChargerControllerRxDataImpl {
+  uint16_t voltage;
+  uint16_t current;
+  ChargerStatus status_flags;
+} ChargerControllerRxDataImpl;
+
+typedef union ChargerControllerRxData {
+  uint64_t raw_data;
+  ChargerControllerRxDataImpl data_impl;
+} ChargerControllerRxData;
+
+// Initializes the charger controller. Expects |settings| to be fully populated.
+StatusCode charger_controller_init(ChargerSettings *settings, ChargerStatus *status);
+
+// Communicates with charger regarding what should be happening.
+StatusCode charger_controller_set_state(ChargerState state);
+
+// Checks that |status| indicates a safe state.
+bool charger_controller_is_safe(ChargerStatus status);

--- a/projects/charger/src/charger_controller.c
+++ b/projects/charger/src/charger_controller.c
@@ -1,0 +1,127 @@
+#include "charger_controller.h"
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "can_interval.h"
+#include "can_transmit.h"
+#include "charger_events.h"
+#include "event_queue.h"
+#include "generic_can.h"
+#include "generic_can_msg.h"
+#include "status.h"
+
+#define CHARGER_PERIOD_US 1000000  // 1 Second as defined in datasheet.
+
+#define CHARGER_EXPECTED_RX_DLC 5
+#define CHARGER_EXPECTED_RX_ID 0x18FF50E5
+
+#define CHARGER_EXPECTED_TX_DLC 5
+#define CHARGER_EXPECTED_TX_ID 0x1806E5F4
+
+static CanInterval *s_interval;
+static ChargerStatus *s_charger_status;
+static GenericCanMsg s_tx_msg;
+
+typedef union J1939CanId {
+  uint32_t raw_id;
+  struct {
+    uint32_t source_address : 8;  // Source
+    uint32_t pdu_specifics : 8;   // Destination
+    uint32_t pdu_format : 8;      // Packet Format
+    uint32_t dp : 1;              // Always 0
+    uint32_t r : 1;               // Always 0
+    uint32_t priority : 3;        // Anything
+  };
+} J1939CanId;
+
+// Explicit for readability.
+static const J1939CanId s_rx_id = {
+  .source_address = 0xE5,  // Indicates BMS in the J1939 standard.
+  .pdu_specifics = 0x50,   // Broadcast address (BCA) id.
+  .pdu_format = 0xFF,      // From datasheet.
+  .dp = 0,
+  .r = 0,
+  .priority = 0x06,  // From datasheet.
+};
+static const J1939CanId s_tx_id = {
+  .source_address = 0xF4,  // Indicates BMS in the J1939 standard.
+  .pdu_specifics = 0xE5,   // Charger control system (CCS) id.
+  .pdu_format = 0x06,      // From datasheet.
+  .dp = 0,
+  .r = 0,
+  .priority = 0x06,  // From datasheet.
+};
+
+// GenericCanRx
+static void prv_rx_handler(const GenericCanMsg *msg, void *context) {
+  (void)context;
+  // TODO(ELEC-355): Rebroadcast this message after transform to the car.
+
+  const ChargerControllerRxData data = {
+    .raw_data = msg->data,
+  };
+  *s_charger_status = data.data_impl.status_flags;
+
+  // Check for statuses
+  if (!charger_controller_is_safe(data.data_impl.status_flags)) {
+    // If unsafe immediately stop charging and force the FSM to transition to the unsafe state.
+    charger_controller_set_state(CHARGER_STATE_STOP);
+    event_raise(CHARGER_EVENT_STOP_CHARGING, 0);
+  }
+}
+
+StatusCode charger_controller_init(ChargerSettings *settings, ChargerStatus *status) {
+  assert(s_tx_id.raw_id == CHARGER_EXPECTED_TX_ID);
+  assert(s_rx_id.raw_id == CHARGER_EXPECTED_RX_ID);
+  s_charger_status = status;
+
+  const ChargerControllerTxData tx_data = { .data_impl = {
+                                                .max_voltage = settings->max_voltage,
+                                                .max_current = settings->max_current,
+                                                .charging = CHARGER_STATE_STOP,
+                                            } };
+
+  s_tx_msg.id = s_tx_id.raw_id;
+  s_tx_msg.dlc = CHARGER_EXPECTED_TX_DLC;
+  s_tx_msg.data = tx_data.raw_data;
+  s_tx_msg.extended = true;
+
+  status_ok_or_return(
+      can_interval_factory(settings->can_uart, &s_tx_msg, CHARGER_PERIOD_US, &s_interval));
+
+  status_ok_or_return(generic_can_register_rx(settings->can_uart, prv_rx_handler,
+                                              GENERIC_CAN_EMPTY_MASK, s_rx_id.raw_id, true,
+                                              settings->can));
+  status_ok_or_return(can_interval_enable(s_interval));
+  return STATUS_CODE_OK;
+}
+
+StatusCode charger_controller_set_state(ChargerState state) {
+  if (state >= NUM_CHARGER_STATES) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  } else if (!charger_controller_is_safe(*s_charger_status)) {
+    // Unsafe to start
+    return status_code(STATUS_CODE_INTERNAL_ERROR);
+  }
+  // TODO(ELEC-355): Consider disabling rx rebroadcasts if off (1/s).
+
+  ChargerControllerTxData tx_data = {
+    .raw_data = s_tx_msg.data,
+  };
+
+  tx_data.data_impl.charging = state;
+  s_tx_msg.data = tx_data.raw_data;
+  return can_interval_send_now(s_interval);
+}
+
+bool charger_controller_is_safe(ChargerStatus status) {
+  // - Input voltage is an indication the charger is lower voltage the battery so don't charge.
+  // - Over Temp is an indication of a heat issue with the charger, it is possible to resume
+  //   charging after a break.
+  // - HW fault is an indeterminate hardware failure which should be addressed.
+  //
+  // Implicitly forgives communication issues.
+  return !(status.input_voltage || status.over_temp || status.hw_fault);
+}

--- a/projects/charger/test/test_charger_controller.c
+++ b/projects/charger/test/test_charger_controller.c
@@ -1,0 +1,158 @@
+#include "charger_controller.h"
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "can_interval.h"
+#include "charger_events.h"
+#include "delay.h"
+#include "event_queue.h"
+#include "generic_can_hw.h"
+#include "gpio.h"
+#include "interrupt.h"
+#include "log.h"
+#include "soft_timer.h"
+#include "test_helpers.h"
+#include "unity.h"
+
+#define TEST_CHARGER_MAX_VOLTAGE 100
+#define TEST_CHARGER_MAX_CURRENT 200
+
+// Opposite of the ones in the charger so that
+#define TEST_CHARGER_EXPECTED_DLC 5
+#define TEST_CHARGER_EXPECTED_TX_ID 0x18FF50E5
+#define TEST_CHARGER_EXPECTED_RX_ID 0x1806E5F4
+
+static uint8_t s_counter;
+static GenericCanHw s_can;
+static ChargerState s_expected_state;
+
+static void prv_send_status(ChargerStatus status) {
+  const ChargerControllerRxData tx_data = {
+    .data_impl =
+        {
+            .voltage = TEST_CHARGER_MAX_VOLTAGE,
+            .current = TEST_CHARGER_MAX_VOLTAGE,
+            .status_flags =
+                {
+                    .raw = status.raw,
+                },
+        },
+  };
+
+  const GenericCanMsg response = {
+    .id = TEST_CHARGER_EXPECTED_TX_ID,
+    .dlc = TEST_CHARGER_EXPECTED_DLC,
+    .extended = true,
+    .data = tx_data.raw_data,
+  };
+
+  generic_can_tx((GenericCan *)&s_can, &response);
+}
+
+static void prv_rx_handler(const GenericCanMsg *msg, void *context) {
+  LOG_DEBUG("CB triggered\n");
+  ChargerStatus *status = context;
+  ChargerControllerTxData data = { .raw_data = msg->data };
+  TEST_ASSERT_EQUAL(TEST_CHARGER_EXPECTED_RX_ID, msg->id);
+  TEST_ASSERT_EQUAL(TEST_CHARGER_MAX_CURRENT, data.data_impl.max_current);
+  TEST_ASSERT_EQUAL(TEST_CHARGER_MAX_VOLTAGE, data.data_impl.max_voltage);
+  TEST_ASSERT_EQUAL(s_expected_state, data.data_impl.charging);
+  TEST_ASSERT_EQUAL(TEST_CHARGER_EXPECTED_DLC, msg->dlc);
+  TEST_ASSERT_TRUE(msg->extended);
+
+  prv_send_status(*status);
+
+  s_counter++;
+}
+
+void setup_test(void) {
+  s_counter = 0;
+  s_expected_state = NUM_CHARGER_STATES;
+  interrupt_init();
+  gpio_init();
+  soft_timer_init();
+  can_interval_init();
+
+  const CANHwSettings can_hw_settings = {
+    .bitrate = CAN_HW_BITRATE_250KBPS,
+    .tx = { GPIO_PORT_A, 12 },
+    .rx = { GPIO_PORT_A, 11 },
+    .loopback = true,
+  };
+
+  TEST_ASSERT_OK(generic_can_hw_init(&s_can, &can_hw_settings, CHARGER_EVENT_CAN_FAULT));
+}
+
+void teardown_test(void) {}
+
+void test_charger_controller(void) {
+  GenericCan *can = (GenericCan *)&s_can;
+  ChargerStatus returned_status = { 0 };
+
+  TEST_ASSERT_OK(generic_can_register_rx(can, prv_rx_handler, GENERIC_CAN_EMPTY_MASK,
+                                         TEST_CHARGER_EXPECTED_RX_ID, true, &returned_status));
+
+  ChargerSettings settings = {
+    .max_voltage = TEST_CHARGER_MAX_VOLTAGE,
+    .max_current = TEST_CHARGER_MAX_CURRENT,
+    .can = can,  // Use pure HW can for both CAN and CAN UART since Extended support is needed.
+    .can_uart = can,
+  };
+
+  Event e = { 0, 0 };
+  ChargerStatus status = { 0 };
+
+  // Starts in stop mode
+  s_expected_state = CHARGER_STATE_STOP;
+  TEST_ASSERT_OK(charger_controller_init(&settings, &status));
+
+  // Let the callback trigger
+  delay_ms(250);
+
+  // Start the charger
+  s_expected_state = CHARGER_STATE_START;
+  TEST_ASSERT_OK(charger_controller_set_state(CHARGER_STATE_START));
+  // Let the callback trigger
+  delay_ms(250);
+
+  s_expected_state = CHARGER_STATE_STOP;
+  returned_status.hw_fault = true;
+  prv_send_status(returned_status);
+  // Let the send occur
+  delay_ms(250);
+
+  TEST_ASSERT_EQUAL(returned_status.raw, status.raw);
+  delay_ms(250);
+
+  // Prevent starting under a fault.
+  TEST_ASSERT_EQUAL(STATUS_CODE_INTERNAL_ERROR, charger_controller_set_state(CHARGER_STATE_START));
+
+  returned_status.hw_fault = false;
+  prv_send_status(returned_status);
+  // Let the send occur
+  delay_ms(250);
+
+  s_expected_state = CHARGER_STATE_START;
+  TEST_ASSERT_OK(charger_controller_set_state(CHARGER_STATE_START));
+  // Let the callback trigger twice
+  delay_ms(1250);
+
+  TEST_ASSERT_EQUAL(5, s_counter);
+}
+
+void test_charger_controller_status(void) {
+  ChargerStatus status = {
+    .hw_fault = false,
+    .over_temp = false,
+    .input_voltage = false,
+  };
+
+  TEST_ASSERT_TRUE(charger_controller_is_safe(status));
+  // Check all combinations of the first 3 flags return false;
+  for (uint8_t i = 1; i < (1U << 3U); i++) {
+    LOG_DEBUG("%u\n", i);
+    status.raw = i;
+    TEST_ASSERT_FALSE(charger_controller_is_safe(status));
+  }
+}


### PR DESCRIPTION
This module is responsible for conversing with the Charger itself over CAN. It has a few responsibilities.

When signaled by Power Distribution to do so:
- Send periodic charging request with voltage and current limits (these are fixed 
for now but could be dynamic).
- Send stop charging requests when the car exits the Charge state.

Monitor messages sent by the Charger for a fault and expose this fault information to its caller. The idea here is that if the charger faults we should stop charging. The point of exposing the status is to prevent re-entry into the Charging state in the event the bad status persists. The reason to attempt to re-enter the charging state is that it is possible for the fault to clear naturally. An example of a valid case for this would be a temporary over-temperature condition which will naturally clear eventually.

As for the CAN interface between power distribution and the charger; the charger will notify power distribution it is connected. At this point power distribution will either already be charging. Or will attempt to transition to charging (only works if in idle). Once in charging power distribution will signal the charger to "close". This will cause the charger to act as if it were a "best-effort" relay which attempts to charge when "closed" but has the potential to "open" itself on a fault. While it is "open" but power distribution has told it to "close" it will attempt to re-enter charging periodically but will only do so successfully if the fault clears. Signaling the charger to "open" is always successful.
