### PR TITLE
ELEC-386: Fixed x86 CAN HW deadlock

### DIFF
--- a/libraries/ms-common/src/x86/can_hw.c
+++ b/libraries/ms-common/src/x86/can_hw.c
@@ -11,6 +11,7 @@
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+#include <semaphore.h>
 #include "fifo.h"
 #include "log.h"
 
@@ -38,8 +39,8 @@ typedef struct CANHwSocketData {
 
 static pthread_t s_rx_pthread_id;
 static pthread_t s_tx_pthread_id;
-static pthread_mutex_t s_tx_mutex = PTHREAD_MUTEX_INITIALIZER;
-static pthread_cond_t s_tx_cond = PTHREAD_COND_INITIALIZER;
+// Producer/Consumer semaphore
+static sem_t s_tx_sem;
 
 // Locked if the TX/RX threads should be alive, unlocked on exit
 static pthread_mutex_t s_keep_alive = PTHREAD_MUTEX_INITIALIZER;
@@ -96,20 +97,9 @@ static void *prv_tx_thread(void *arg) {
 
   // Mutex is unlocked when the thread should exit
   while (pthread_mutex_trylock(&s_keep_alive) != 0) {
-    pthread_mutex_lock(&s_tx_mutex);
-    while (fifo_size(&s_socket_data.tx_fifo) == 0) {
-      pthread_cond_wait(&s_tx_cond, &s_tx_mutex);
-
-      if (pthread_mutex_trylock(&s_keep_alive) == 0) {
-        // Mutex was unlocked and we were able to lock it
-        pthread_mutex_unlock(&s_keep_alive);
-        break;
-      }
-    }
-
+    // Wait until the producer has created an item
+    sem_wait(&s_tx_sem);
     fifo_pop(&s_socket_data.tx_fifo, &frame);
-    pthread_mutex_unlock(&s_tx_mutex);
-
     int bytes = write(s_socket_data.can_fd, &frame, sizeof(frame));
 
     // Delay to simulate bus speed
@@ -135,17 +125,16 @@ StatusCode can_hw_init(const CANHwSettings *settings) {
 
     pthread_join(s_rx_pthread_id, NULL);
 
-    // Signal condition variable in case TX thread is waiting
-    pthread_mutex_lock(&s_tx_mutex);
-    pthread_mutex_unlock(&s_tx_mutex);
-    pthread_cond_signal(&s_tx_cond);
+    // Allow the TX thread to continue
+    sem_post(&s_tx_sem);
 
+    sem_destroy(&s_tx_sem);
     pthread_join(s_tx_pthread_id, NULL);
   }
 
   pthread_mutex_init(&s_keep_alive, NULL);
-  pthread_mutex_init(&s_tx_mutex, NULL);
-  pthread_cond_init(&s_tx_cond, NULL);
+  // Init semaphore to thread-shared and locked
+  sem_init(&s_tx_sem, 0, 0);
 
   pthread_mutex_lock(&s_keep_alive);
 
@@ -237,16 +226,13 @@ StatusCode can_hw_transmit(uint32_t id, bool extended, const uint8_t *data, size
   struct can_frame frame = { .can_id = (id & mask) | extended_bit, .can_dlc = len };
   memcpy(&frame.data, data, len);
 
-  pthread_mutex_lock(&s_tx_mutex);
   StatusCode ret = fifo_push(&s_socket_data.tx_fifo, &frame);
   if (ret != STATUS_CODE_OK) {
     // Fifo is full
-    pthread_mutex_unlock(&s_tx_mutex);
     return status_msg(STATUS_CODE_RESOURCE_EXHAUSTED, "CAN HW TX failed");
   }
-
-  pthread_cond_signal(&s_tx_cond);
-  pthread_mutex_unlock(&s_tx_mutex);
+  // Unblock TX thread
+  sem_post(&s_tx_sem);
 
   return STATUS_CODE_OK;
 }

--- a/libraries/ms-common/src/x86/can_hw.c
+++ b/libraries/ms-common/src/x86/can_hw.c
@@ -5,13 +5,13 @@
 #include <net/if.h>
 #include <poll.h>
 #include <pthread.h>
+#include <semaphore.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
-#include <semaphore.h>
 #include "fifo.h"
 #include "log.h"
 


### PR DESCRIPTION
There was a deadlock between the CAN TX thread and `can_hw_transmit` called from the soft timer signal handler.

> The TX thread is holding the TX mutex while the critical section mutex is held by the main thread in the soft timer signal handler. This causes a deadlock because the TX thread attempts to acquire the critical section mutex to process the FIFO while the main thread attempts to acquire the TX mutex to push data using can_hw_transmit.

This fix removes the TX mutex entirely and replaces it with a semaphore since this is a producer/consumer scenario.