### PR TITLE
ELEC-386: Mask signal handling in CAN RX/TX Threads

### DIFF
--- a/libraries/ms-common/src/x86/can_hw.c
+++ b/libraries/ms-common/src/x86/can_hw.c
@@ -1,17 +1,21 @@
 #include "can_hw.h"
+
 #include <fcntl.h>
 #include <linux/can.h>
 #include <linux/can/raw.h>
 #include <net/if.h>
 #include <poll.h>
 #include <pthread.h>
+#include <signal.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>
+
 #include "fifo.h"
+#include "interrupt_def.h"
 #include "log.h"
 
 #define CAN_HW_DEV_INTERFACE "vcan0"
@@ -36,6 +40,7 @@ typedef struct CANHwSocketData {
   uint32_t delay_us;
 } CANHwSocketData;
 
+static sigset_t s_signal_mask;
 static pthread_t s_rx_pthread_id;
 static pthread_t s_tx_pthread_id;
 static pthread_mutex_t s_tx_mutex = PTHREAD_MUTEX_INITIALIZER;
@@ -58,6 +63,7 @@ static uint32_t prv_get_delay(CANHwBitrate bitrate) {
 }
 
 static void *prv_rx_thread(void *arg) {
+  pthread_sigmask(SIG_BLOCK, &s_signal_mask, NULL);
   LOG_DEBUG("CAN HW RX thread started\n");
 
   struct timeval timeout = { .tv_usec = CAN_HW_THREAD_EXIT_PERIOD_US };
@@ -91,6 +97,7 @@ static void *prv_rx_thread(void *arg) {
 }
 
 static void *prv_tx_thread(void *arg) {
+  pthread_sigmask(SIG_BLOCK, &s_signal_mask, NULL);
   LOG_DEBUG("CAN HW TX thread started\n");
   struct can_frame frame = { 0 };
 
@@ -127,6 +134,11 @@ static void *prv_tx_thread(void *arg) {
 }
 
 StatusCode can_hw_init(const CANHwSettings *settings) {
+  sigemptyset(&s_signal_mask);
+  sigaddset(&s_signal_mask, SIGRTMIN + INTERRUPT_PRIORITY_LOW);
+  sigaddset(&s_signal_mask, SIGRTMIN + INTERRUPT_PRIORITY_NORMAL);
+  sigaddset(&s_signal_mask, SIGRTMIN + INTERRUPT_PRIORITY_HIGH);
+
   if (s_socket_data.can_fd != -1) {
     // Request threads to exit
     close(s_socket_data.can_fd);


### PR DESCRIPTION
According to [`signal (7)`](http://man7.org/linux/man-pages/man7/signal.7.html), signals are indeterminate in which thread of a particular process they trigger. As a result the CAN TX or RX threads often handled the signal. This isn't good since it can lead to some strange behaviors regarding mutex ownership. To get around this we mask the pthreads individually from receiving signals as they are spawned via [`pthread_sigmask`](http://pubs.opengroup.org/onlinepubs/9699919799/functions/pthread_sigmask.html).

Since CAN Hardware is the only location we use pthreads we can limit the change to this module. We could make this a function under `interrupt.h` if we expect it to be more widely used.