### PR TITLE
ELEC-105: Fix error in test_charger.c

### DIFF
--- a/projects/chaos/test/test_charger.c
+++ b/projects/chaos/test/test_charger.c
@@ -12,6 +12,7 @@
 #include "gpio.h"
 #include "interrupt.h"
 #include "ms_test_helpers.h"
+#include "soft_timer.h"
 #include "status.h"
 #include "test_helpers.h"
 #include "unity.h"
@@ -38,6 +39,7 @@ void setup_test(void) {
   interrupt_init();
   gpio_init();
   event_queue_init();
+  soft_timer_init();
 
   const CANSettings settings = {
     .device_id = SYSTEM_CAN_DEVICE_CHAOS,


### PR DESCRIPTION
I have no idea how this was passing Travis or on my machine previously. The latest glibc on my machine (as of yesterday) just segfaults when I forget to init timers...