### PR TITLE
ELEC-423: Relay RX

### DIFF
--- a/libraries/ms-helper/inc/relay_rx.h
+++ b/libraries/ms-helper/inc/relay_rx.h
@@ -7,18 +7,19 @@
 // configured to unpack relay messages and handle faults. This RelayRxHandler is expected to execute
 // the modifications to any GPIO pins or other mechanisms to trigger state changes to relays.
 
+#include <stdint.h>
+
 #include "can_msg_defs.h"
-#include "exported_enums.h"
 #include "status.h"
 
 // Wrapped by a CANRxHandlerCb.
-typedef StatusCode (*RelayRxHandler)(SystemCanMessage msg_id, EEChaosCmdRelayState state,
-                                     void *context);
+typedef StatusCode (*RelayRxHandler)(SystemCanMessage msg_id, uint8_t state, void *context);
 
 typedef struct RelayRxStorage {
   RelayRxHandler handler;
   SystemCanMessage msg_id;  // Unused but helpful in debugging.
-  EEChaosCmdRelayState curr_state;
+  uint8_t curr_state;
+  uint8_t state_bound;
   void *context;
 } RelayRxStorage;
 
@@ -28,11 +29,12 @@ StatusCode relay_rx_init(RelayRxStorage *relay_storage, size_t size);
 
 // Relay RX init configures |RelayRxHandler| to be triggered when |msg_id| is received. This handler
 // should alter a relay or relays to be in-keeping with the expected state. In the event of a
-// failure the status code should propagate back to the CANRxHandler.
+// failure the status code should propagate back to the CANRxHandler. |state_bound| is the
+// non-inclusive upper bound on the values the returned uint8_t can be.
 //
 // NOTE: we explicitly don't constrain |msg_id|. In theory we could force this to be a value
 // defined for one of the relays in codegen-tooling. But this module could be used for any CAN
 // controlled element that uses a message format of a single uint8_t. Also note that the
 // |relay_storage| is also extensible for this reason.
-StatusCode relay_rx_configure_handler(SystemCanMessage msg_id, RelayRxHandler handler,
-                                      void *context);
+StatusCode relay_rx_configure_handler(SystemCanMessage msg_id, uint8_t state_bound,
+                                      RelayRxHandler handler, void *context);

--- a/libraries/ms-helper/inc/relay_rx.h
+++ b/libraries/ms-helper/inc/relay_rx.h
@@ -23,18 +23,15 @@ typedef struct RelayRxStorage {
   void *context;
 } RelayRxStorage;
 
-// Initialize the relay module to use the supplied |relay_storage| of |size| to hold relay
-// configurations.
-StatusCode relay_rx_init(RelayRxStorage *relay_storage, size_t size);
-
 // Relay RX init configures |RelayRxHandler| to be triggered when |msg_id| is received. This handler
 // should alter a relay or relays to be in-keeping with the expected state. In the event of a
 // failure the status code should propagate back to the CANRxHandler. |state_bound| is the
-// non-inclusive upper bound on the values the returned uint8_t can be.
+// non-inclusive upper bound on the values the returned uint8_t can be. The configuration is stored
+// in |storage|.
 //
 // NOTE: we explicitly don't constrain |msg_id|. In theory we could force this to be a value
 // defined for one of the relays in codegen-tooling. But this module could be used for any CAN
 // controlled element that uses a message format of a single uint8_t. Also note that the
 // |relay_storage| is also extensible for this reason.
-StatusCode relay_rx_configure_handler(SystemCanMessage msg_id, uint8_t state_bound,
-                                      RelayRxHandler handler, void *context);
+StatusCode relay_rx_configure_handler(RelayRxStorage *storage, SystemCanMessage msg_id,
+                                      uint8_t state_bound, RelayRxHandler handler, void *context);

--- a/libraries/ms-helper/inc/relay_rx.h
+++ b/libraries/ms-helper/inc/relay_rx.h
@@ -1,0 +1,38 @@
+#pragma once
+// Module for interfacing to CAN for CAN controlled relays.
+//
+// Requires CAN to be initialized.
+//
+// Allows registering a RelayRxHandler that is wrapped by a CANRxHandlerCb which is properly
+// configured to unpack relay messages and handle faults. This RelayRxHandler is expected to execute
+// the modifications to any GPIO pins or other mechanisms to trigger state changes to relays.
+
+#include "can_msg_defs.h"
+#include "exported_enums.h"
+#include "status.h"
+
+// Wrapped by a CANRxHandlerCb.
+typedef StatusCode (*RelayRxHandler)(SystemCanMessage msg_id, EEChaosCmdRelayState state,
+                                     void *context);
+
+typedef struct RelayRxStorage {
+  RelayRxHandler handler;
+  SystemCanMessage msg_id;  // Unused but helpful in debugging.
+  EEChaosCmdRelayState curr_state;
+  void *context;
+} RelayRxStorage;
+
+// Initialize the relay module to use the supplied |relay_storage| of |size| to hold relay
+// configurations.
+StatusCode relay_rx_init(RelayRxStorage *relay_storage, size_t size);
+
+// Relay RX init configures |RelayRxHandler| to be triggered when |msg_id| is received. This handler
+// should alter a relay or relays to be in-keeping with the expected state. In the event of a
+// failure the status code should propagate back to the CANRxHandler.
+//
+// NOTE: we explicitly don't constrain |msg_id|. In theory we could force this to be a value
+// defined for one of the relays in codegen-tooling. But this module could be used for any CAN
+// controlled element that uses a message format of a single uint8_t. Also note that the
+// |relay_storage| is also extensible for this reason.
+StatusCode relay_rx_configure_handler(SystemCanMessage msg_id, RelayRxHandler handler,
+                                      void *context);

--- a/libraries/ms-helper/inc/relay_rx.h
+++ b/libraries/ms-helper/inc/relay_rx.h
@@ -5,7 +5,9 @@
 //
 // Allows registering a RelayRxHandler that is wrapped by a CANRxHandlerCb which is properly
 // configured to unpack relay messages and handle faults. This RelayRxHandler is expected to execute
-// the modifications to any GPIO pins or other mechanisms to trigger state changes to relays.
+// the modifications to any GPIO pins or other mechanisms to trigger state changes to relays and
+// report them back to the CANRxHanderCb which will handle the ack. These should ideally be kept
+// very short, just GPIO manipulation or enqueueing events!
 
 #include <stdint.h>
 
@@ -19,19 +21,20 @@ typedef struct RelayRxStorage {
   RelayRxHandler handler;
   SystemCanMessage msg_id;  // Unused but helpful in debugging.
   uint8_t curr_state;
-  uint8_t state_bound;
+  uint8_t state_bound;  // Non-inclusive upper bound |[0, state_bound)| on |curr_state|.
   void *context;
 } RelayRxStorage;
 
-// Relay RX init configures |RelayRxHandler| to be triggered when |msg_id| is received. This handler
-// should alter a relay or relays to be in-keeping with the expected state. In the event of a
-// failure the status code should propagate back to the CANRxHandler. |state_bound| is the
-// non-inclusive upper bound on the values the returned uint8_t can be. The configuration is stored
-// in |storage|.
+// Configures |RelayRxHandler| to be triggered when |msg_id| is received. This handler should alter
+// a relay or set of relays to match the expected state. In the event of a failure the status code
+// should propagate back to the CANRxHandler. |state_bound| is the non-inclusive upper bound on the
+// values the returned uint8_t can be. The configuration is stored in |storage|. If the relay is
+// already in the expected state |handler| should still return with STATUS_CODE_OK so long as there
+// are no faults.
 //
 // NOTE: we explicitly don't constrain |msg_id|. In theory we could force this to be a value
 // defined for one of the relays in codegen-tooling. But this module could be used for any CAN
 // controlled element that uses a message format of a single uint8_t. Also note that the
-// |relay_storage| is also extensible for this reason.
+// |storage| is also extensible for this reason.
 StatusCode relay_rx_configure_handler(RelayRxStorage *storage, SystemCanMessage msg_id,
                                       uint8_t state_bound, RelayRxHandler handler, void *context);

--- a/libraries/ms-helper/src/relay_rx.c
+++ b/libraries/ms-helper/src/relay_rx.c
@@ -1,0 +1,76 @@
+#include "relay_rx.h"
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <string.h>
+
+#include "can.h"
+#include "can_msg_defs.h"
+#include "can_unpack.h"
+#include "critical_section.h"
+#include "exported_enums.h"
+#include "gpio.h"
+#include "status.h"
+
+static RelayRxStorage *s_storage;
+static size_t s_storage_size;
+static size_t s_storage_idx;
+
+// CANRxHandler
+static StatusCode prv_relay_rx_can_handler(const CANMessage *msg, void *context,
+                                           CANAckStatus *ack_reply) {
+  RelayRxStorage *storage = context;
+  EEChaosCmdRelayState state = NUM_EE_CHAOS_CMD_RELAY_STATES;
+  // NOTE: This is a bit of a hack that exploits the fact all the relay control messages are the
+  // same. The aim here is to not necessarily force a constraint based on message id/name. Instead
+  // all single field u8 messages will succeed in unpacking but the contents must be valid.
+  CAN_UNPACK_BATTERY_RELAY(msg, (uint8_t *)&state);
+  if (state >= NUM_EE_CHAOS_CMD_RELAY_STATES) {
+    *ack_reply = CAN_ACK_STATUS_INVALID;
+  } else {
+    storage->curr_state = state;
+    if (!status_ok(storage->handler(storage->msg_id, storage->curr_state, storage->context))) {
+      *ack_reply = CAN_ACK_STATUS_INVALID;
+    }
+  }
+  return STATUS_CODE_OK;
+}
+
+StatusCode relay_rx_init(RelayRxStorage *relay_storage, size_t size) {
+  if (size == 0) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+  s_storage = relay_storage;
+  memset(relay_storage, 0, size);
+  s_storage_size = size;
+  s_storage_idx = 0;
+  return STATUS_CODE_OK;
+}
+
+StatusCode relay_rx_configure_handler(SystemCanMessage msg_id, RelayRxHandler handler,
+                                      void *context) {
+  if (s_storage_idx >= s_storage_size) {
+    return status_code(STATUS_CODE_RESOURCE_EXHAUSTED);
+  } else if (handler == NULL) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+  // NOTE: we explicitly don't constrain |msg_id|. In theory we could force this to be a value
+  // defined for one of the relays in codegen-tooling. But in theory this module could be used for
+  // any CAN controlled GPIO. Also note that the storage is also extensible for this reason.
+
+  bool disabled_in_scope = critical_section_start();
+  StatusCode status =
+      can_register_rx_handler(msg_id, prv_relay_rx_can_handler, &s_storage[s_storage_idx]);
+  if (!status_ok(status)) {
+    critical_section_end(disabled_in_scope);
+    return status;
+  }
+
+  s_storage[s_storage_idx].handler = handler;
+  s_storage[s_storage_idx].msg_id = msg_id;
+  s_storage[s_storage_idx].curr_state = EE_CHAOS_CMD_RELAY_STATE_OPEN;
+  s_storage[s_storage_idx].context = context;
+  s_storage_idx++;
+  critical_section_end(disabled_in_scope);
+  return STATUS_CODE_OK;
+}

--- a/libraries/ms-helper/test/test_relay_rx.c
+++ b/libraries/ms-helper/test/test_relay_rx.c
@@ -1,0 +1,154 @@
+#include "relay_rx.h"
+
+#include <stdbool.h>
+
+#include "can.h"
+#include "can_ack.h"
+#include "can_msg_defs.h"
+#include "can_transmit.h"
+#include "exported_enums.h"
+#include "gpio.h"
+#include "gpio_mcu.h"
+#include "interrupt.h"
+#include "log.h"
+#include "ms_test_helpers.h"
+#include "soft_timer.h"
+#include "status.h"
+#include "test_helpers.h"
+#include "unity.h"
+
+#define TEST_RELAY_CAN_DEVICE_ID 10
+#define NUM_TEST_RELAY_RX_CAN_HANDLERS 3
+#define NUM_TEST_RELAY_RX_STORAGE_HANDLERS 2
+
+typedef enum {
+  TEST_RELAY_RX_CAN_RX = 10,
+  TEST_RELAY_RX_CAN_TX,
+  TEST_RELAY_RX_CAN_FAULT,
+} TestCanEvent;
+
+typedef struct TestRelayRxHandlerCtx {
+  StatusCode ret_code;
+  SystemCanMessage expected_msg_id;
+  EEChaosCmdRelayState expected_state;
+  bool executed;
+} TestRelayRxHandlerCtx;
+
+static const Event s_tx_event = { TEST_RELAY_RX_CAN_TX, 0 };
+static const Event s_rx_event = { TEST_RELAY_RX_CAN_RX, 0 };
+static RelayRxStorage s_relay_storage[NUM_TEST_RELAY_RX_STORAGE_HANDLERS];
+static CANStorage s_can_storage;
+static CANAckRequests s_can_ack_requests;
+static CANRxHandler s_rx_handlers[NUM_TEST_RELAY_RX_STORAGE_HANDLERS];
+
+// CANAckRequestCb
+static StatusCode prv_ack_callback(CANMessageID msg_id, uint16_t device, CANAckStatus status,
+                                   uint16_t num_remaining, void *context) {
+  (void)num_remaining;
+  CANAckStatus *expected_status = context;
+  TEST_ASSERT_EQUAL(SYSTEM_CAN_MESSAGE_BATTERY_RELAY, msg_id);
+  TEST_ASSERT_EQUAL(TEST_RELAY_CAN_DEVICE_ID, device);
+  TEST_ASSERT_EQUAL(*expected_status, status);
+  return STATUS_CODE_OK;
+}
+
+// RelayRxHandler
+static StatusCode prv_relay_rx_handler(SystemCanMessage msg_id, EEChaosCmdRelayState state,
+                                       void *context) {
+  TestRelayRxHandlerCtx *data = context;
+  TEST_ASSERT_EQUAL(data->expected_msg_id, msg_id);
+  TEST_ASSERT_EQUAL(data->expected_state, state);
+  data->executed = true;
+  return data->ret_code;
+}
+
+void setup_test(void) {
+  event_queue_init();
+  interrupt_init();
+  soft_timer_init();
+
+  CANSettings can_settings = {
+    .device_id = TEST_RELAY_CAN_DEVICE_ID,
+    .bitrate = CAN_HW_BITRATE_125KBPS,
+    .rx_event = TEST_RELAY_RX_CAN_RX,
+    .tx_event = TEST_RELAY_RX_CAN_TX,
+    .fault_event = TEST_RELAY_RX_CAN_FAULT,
+    .tx = { GPIO_PORT_A, 12 },
+    .rx = { GPIO_PORT_A, 11 },
+    .loopback = true,
+  };
+  TEST_ASSERT_OK(
+      can_init(&can_settings, &s_can_storage, s_rx_handlers, NUM_TEST_RELAY_RX_CAN_HANDLERS));
+  can_ack_init(&s_can_ack_requests);
+}
+
+void teardown_test(void) {}
+
+void test_relay_rx_guards(void) {
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, relay_rx_init(s_relay_storage, 0));
+  TEST_ASSERT_OK(relay_rx_init(s_relay_storage, NUM_TEST_RELAY_RX_STORAGE_HANDLERS));
+
+  TestRelayRxHandlerCtx context = {
+    .ret_code = STATUS_CODE_OK,
+    .expected_msg_id = SYSTEM_CAN_MESSAGE_BATTERY_RELAY,
+    .expected_state = EE_CHAOS_CMD_RELAY_STATE_OPEN,
+    .executed = false,
+  };
+  TEST_ASSERT_OK(
+      relay_rx_configure_handler(SYSTEM_CAN_MESSAGE_BATTERY_RELAY, prv_relay_rx_handler, &context));
+  // Fail to register duplicates.
+  TEST_ASSERT_EQUAL(
+      STATUS_CODE_RESOURCE_EXHAUSTED,
+      relay_rx_configure_handler(SYSTEM_CAN_MESSAGE_BATTERY_RELAY, prv_relay_rx_handler, &context));
+  TEST_ASSERT_OK(
+      relay_rx_configure_handler(SYSTEM_CAN_MESSAGE_MAIN_RELAY, prv_relay_rx_handler, &context));
+
+  // Fail to register too many.
+  TEST_ASSERT_EQUAL(
+      STATUS_CODE_RESOURCE_EXHAUSTED,
+      relay_rx_configure_handler(SYSTEM_CAN_MESSAGE_MAIN_RELAY, prv_relay_rx_handler, &context));
+}
+
+void test_relay_rx(void) {
+  TEST_ASSERT_OK(relay_rx_init(s_relay_storage, NUM_TEST_RELAY_RX_STORAGE_HANDLERS));
+  TestRelayRxHandlerCtx context = {
+    .ret_code = STATUS_CODE_OK,
+    .expected_msg_id = SYSTEM_CAN_MESSAGE_BATTERY_RELAY,
+    .expected_state = EE_CHAOS_CMD_RELAY_STATE_OPEN,
+    .executed = false,
+  };
+  TEST_ASSERT_OK(
+      relay_rx_configure_handler(SYSTEM_CAN_MESSAGE_BATTERY_RELAY, prv_relay_rx_handler, &context));
+
+  CANAckStatus expected_status = CAN_ACK_STATUS_OK;
+  CANAckRequest req = {
+    .callback = prv_ack_callback,
+    .context = &expected_status,
+    .expected_bitset = CAN_ACK_EXPECTED_DEVICES(TEST_RELAY_CAN_DEVICE_ID),
+  };
+
+  // Open.
+  CAN_TRANSMIT_BATTERY_RELAY(&req, EE_CHAOS_CMD_RELAY_STATE_OPEN);
+  MS_TEST_HELPER_CAN_TX_RX_WITH_ACK(s_tx_event, s_rx_event);
+  TEST_ASSERT_TRUE(context.executed);
+  context.executed = false;
+
+  // Close.
+  context.expected_state = EE_CHAOS_CMD_RELAY_STATE_CLOSE;
+  CAN_TRANSMIT_BATTERY_RELAY(&req, EE_CHAOS_CMD_RELAY_STATE_CLOSE);
+  MS_TEST_HELPER_CAN_TX_RX_WITH_ACK(s_tx_event, s_rx_event);
+  TEST_ASSERT_TRUE(context.executed);
+  context.executed = false;
+
+  // Invalid.
+  expected_status = CAN_ACK_STATUS_INVALID;
+  CAN_TRANSMIT_BATTERY_RELAY(&req, NUM_EE_CHAOS_CMD_RELAY_STATES);
+  MS_TEST_HELPER_CAN_TX_RX_WITH_ACK(s_tx_event, s_rx_event);
+  TEST_ASSERT_FALSE(context.executed);
+
+  // Fail to update relay.
+  context.ret_code = STATUS_CODE_INTERNAL_ERROR;
+  CAN_TRANSMIT_BATTERY_RELAY(&req, EE_CHAOS_CMD_RELAY_STATE_CLOSE);
+  MS_TEST_HELPER_CAN_TX_RX_WITH_ACK(s_tx_event, s_rx_event);
+  TEST_ASSERT_TRUE(context.executed);
+}


### PR DESCRIPTION
A generic Relay RX module that allows for easy registry of Relay RX handlers which handle a simple single field `uint8_t` CAN message. If the state is valid the registered handler will run. It is expected that the handler will usually trigger one or more GPIO pins although this isn't dictated as it may be useful for other purposes. This is really just a fancy wrapper over `can_register_rx_handler` specialized for the purposes of a relay.

The reason this isn't a simple GPIO pin state over CAN protocol is that some modules may have multiple GPIO pins to trigger or may want to raise an event or save state when the relay changes.