### PR TITLE
ELEC-424: Heartbeat Handler

### DIFF
--- a/libraries/ms-helper/inc/heartbeat_rx.h
+++ b/libraries/ms-helper/inc/heartbeat_rx.h
@@ -1,0 +1,27 @@
+#pragma once
+// RX handler for heartbeats.
+//
+// Requires CAN to be initialized.
+//
+// The concept is to simplify registering a CANRxHandler such that it automatically replies in the
+// affirmative to the message unless a callback specifies otherwise. If no handler is specified
+// |NULL| it will always return success.
+
+#include <stdbool.h>
+
+#include "can.h"
+#include "status.h"
+
+// Return true to respond in the affirmative. False to fail the ACK.
+typedef bool (*HeartbeatRxHandler)(CANMessageID msg_id, void *context);
+
+typedef struct HeartbeatRxHandlerStorage {
+  HeartbeatRxHandler handler;
+  void *context;
+} HeartbeatRxHandlerStorage;
+
+// Registers the heartbeat handler (|handler|) to run for |msg_id|. |handler| takes |context| as an
+// argument. This configuration is stored in |storage| which must persist indefinitely. If |handler|
+// is NULL the heartbeat will automatically be acknowledged in the affirmative.
+StatusCode heartbeat_rx_register_handler(HeartbeatRxHandlerStorage *storage, CANMessageID msg_id,
+                                         HeartbeatRxHandler handler, void *context);

--- a/libraries/ms-helper/inc/heartbeat_rx.h
+++ b/libraries/ms-helper/inc/heartbeat_rx.h
@@ -25,3 +25,7 @@ typedef struct HeartbeatRxHandlerStorage {
 // is NULL the heartbeat will automatically be acknowledged in the affirmative.
 StatusCode heartbeat_rx_register_handler(HeartbeatRxHandlerStorage *storage, CANMessageID msg_id,
                                          HeartbeatRxHandler handler, void *context);
+
+// An instance of HeartbeatRxHandler that can be used to automatically ack and return true with no
+// other behavior.
+bool heartbeat_rx_auto_ack(CANMessageID msg_id, void *context);

--- a/libraries/ms-helper/src/heartbeat_rx.c
+++ b/libraries/ms-helper/src/heartbeat_rx.c
@@ -11,7 +11,7 @@
 static StatusCode prv_heartbeat_handler(const CANMessage *msg, void *context,
                                         CANAckStatus *ack_reply) {
   HeartbeatRxHandlerStorage *storage = context;
-  if (storage->handler != NULL && !storage->handler(msg->msg_id, storage->context)) {
+  if (!storage->handler(msg->msg_id, storage->context)) {
     *ack_reply = CAN_ACK_STATUS_INVALID;
   }
   return STATUS_CODE_OK;
@@ -19,12 +19,15 @@ static StatusCode prv_heartbeat_handler(const CANMessage *msg, void *context,
 
 StatusCode heartbeat_rx_register_handler(HeartbeatRxHandlerStorage *storage, CANMessageID msg_id,
                                          HeartbeatRxHandler handler, void *context) {
+  if (handler == NULL || storage == NULL) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
   storage->handler = handler;
   storage->context = context;
   return can_register_rx_handler(msg_id, prv_heartbeat_handler, storage);
 }
 
-bool heartbeat_rx_auto_ack(CANMessageID msg_id, void *context) {
+bool heartbeat_rx_auto_ack_handler(CANMessageID msg_id, void *context) {
   (void)msg_id;
   (void)context;
   return true;

--- a/libraries/ms-helper/src/heartbeat_rx.c
+++ b/libraries/ms-helper/src/heartbeat_rx.c
@@ -1,0 +1,25 @@
+#include "heartbeat_rx.h"
+
+#include <stddef.h>
+
+#include "can.h"
+#include "can_ack.h"
+#include "can_rx.h"
+#include "status.h"
+
+// CANRxHandlerCb
+static StatusCode prv_heartbeat_handler(const CANMessage *msg, void *context,
+                                        CANAckStatus *ack_reply) {
+  HeartbeatRxHandlerStorage *storage = context;
+  if (storage->handler != NULL && !storage->handler(msg->msg_id, storage->context)) {
+    *ack_reply = CAN_ACK_STATUS_INVALID;
+  }
+  return STATUS_CODE_OK;
+}
+
+StatusCode heartbeat_rx_register_handler(HeartbeatRxHandlerStorage *storage, CANMessageID msg_id,
+                                         HeartbeatRxHandler handler, void *context) {
+  storage->handler = handler;
+  storage->context = context;
+  return can_register_rx_handler(msg_id, prv_heartbeat_handler, storage);
+}

--- a/libraries/ms-helper/src/heartbeat_rx.c
+++ b/libraries/ms-helper/src/heartbeat_rx.c
@@ -23,3 +23,9 @@ StatusCode heartbeat_rx_register_handler(HeartbeatRxHandlerStorage *storage, CAN
   storage->context = context;
   return can_register_rx_handler(msg_id, prv_heartbeat_handler, storage);
 }
+
+bool heartbeat_rx_auto_ack(CANMessageID msg_id, void *context) {
+  (void)msg_id;
+  (void)context;
+  return true;
+}

--- a/libraries/ms-helper/test/test_heartbeat_rx.c
+++ b/libraries/ms-helper/test/test_heartbeat_rx.c
@@ -1,6 +1,7 @@
 #include "heartbeat_rx.h"
 
-#include "can.h"
+#include <stdbool.h>
+#include <stdint.h>
 
 #include "can.h"
 #include "can_ack.h"


### PR DESCRIPTION
A simple module to register a handler for heartbeats. This simply reduces the heartbeat handling to a single handler which must be registers. In most cases returning `true` from the handler is sufficient (use `heartbeat_rx_auto_ack`). If more complex behavior is required a custom handler can be registered.