### PR TITLE
ELEC-425: Priority FIFO Event Queue

### DIFF
--- a/libraries/ms-common/inc/event_queue.h
+++ b/libraries/ms-common/inc/event_queue.h
@@ -1,7 +1,7 @@
 #pragma once
 // Global event queue
 //
-// Uses a minimum priority queue to prioritize events of lower ID. Only one global instance exists.
+// Uses an array of FIFOs to prioritize events of lower priority. Only one global instance exists.
 #include <stdint.h>
 
 #include "objpool.h"
@@ -9,6 +9,15 @@
 
 #define EVENT_QUEUE_SIZE 20
 typedef uint16_t EventID;
+
+typedef enum {
+  EVENT_PRIORITY_HIGHEST = 0,
+  EVENT_PRIORITY_HIGH,
+  EVENT_PRIORITY_NORMAL,
+  EVENT_PRIORITY_LOW,
+  EVENT_PRIORITY_LOWEST,
+  NUM_EVENT_PRIORITIES,
+} EventPriority;
 
 typedef struct Event {
   EventID id;
@@ -18,8 +27,12 @@ typedef struct Event {
 // Initializes the event queue.
 void event_queue_init(void);
 
-// Raises an event in the global event queue.
-StatusCode event_raise(EventID id, uint16_t data);
+// Raises an event in the global event queue at the default priority.
+StatusCode event_raise_priority(EventPriority priority, EventID id, uint16_t data);
+
+// Raises an event in the global event queue at the default priority. Provided for legacy
+// compatibility.
+#define event_raise(id, data) event_raise_priority(EVENT_PRIORITY_NORMAL, (id), (data))
 
 // Returns the next event to be processed.
 // Note that events are processed by priority.

--- a/libraries/ms-common/inc/event_queue.h
+++ b/libraries/ms-common/inc/event_queue.h
@@ -2,6 +2,17 @@
 // Global event queue
 //
 // Uses an array of FIFOs to prioritize events of lower priority. Only one global instance exists.
+//
+// Implementation:
+// - Event Queue consists of five FIFOs each of which correspond to a priority.
+// - Raised events are put into the corresponding FIFO.
+// - A processed event will come from the highest priority queue that has elements.
+//
+// For legacy purposes and simplicity for smaller projects |event_raise()| allows events to be
+// raised at the NORMAL (default) priority. In cases where this is prevalent high priority events
+// will preempt most ms-common and ms-helper functionality as well as any board behavior.
+// Additionally, low priority message will effectively become best effort as many events may be
+// raised.
 #include <stdint.h>
 
 #include "objpool.h"

--- a/libraries/ms-common/src/event_queue.c
+++ b/libraries/ms-common/src/event_queue.c
@@ -4,29 +4,39 @@
 #include <string.h>
 
 #include "event_queue.h"
-#include "pqueue_backed.h"
+#include "fifo.h"
+#include "status.h"
 
 typedef struct EventQueue {
-  PQueueBacked pqueue;
-  PQueueNode queue_nodes[EVENT_QUEUE_SIZE + 1];
-  Event event_nodes[EVENT_QUEUE_SIZE];
+  Fifo fifos[NUM_EVENT_PRIORITIES];
+  Event event_nodes[NUM_EVENT_PRIORITIES][EVENT_QUEUE_SIZE];
 } EventQueue;
 
 static EventQueue s_queue;
 
 void event_queue_init(void) {
-  pqueue_backed_init(&s_queue.pqueue, s_queue.queue_nodes, s_queue.event_nodes);
+  for (size_t i = 0; i < NUM_EVENT_PRIORITIES; i++) {
+    fifo_init(&s_queue.fifos[i], s_queue.event_nodes[i]);
+  }
 }
 
-StatusCode event_raise(EventID id, uint16_t data) {
-  const Event e = {
+StatusCode event_raise_priority(EventPriority priority, EventID id, uint16_t data) {
+  if (priority >= NUM_EVENT_PRIORITIES) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+  Event e = {
     .id = id,      //
     .data = data,  //
   };
 
-  return pqueue_backed_push(&s_queue.pqueue, &e, id);
+  return fifo_push(&s_queue.fifos[priority], &e);
 }
 
 StatusCode event_process(Event *e) {
-  return pqueue_backed_pop(&s_queue.pqueue, e);
+  for (size_t i = 0; i < NUM_EVENT_PRIORITIES; i++) {
+    if (s_queue.fifos[i].num_elems > 0) {
+      return fifo_pop(&s_queue.fifos[i], e);
+    }
+  }
+  return status_code(STATUS_CODE_EMPTY);
 }

--- a/libraries/ms-common/test/test_event_queue.c
+++ b/libraries/ms-common/test/test_event_queue.c
@@ -13,6 +13,7 @@ void setup_test(void) {
 
 void teardown_test(void) {}
 
+// Test a single priority level.
 void test_event_queue_raise(void) {
   // Fill the event queue
   for (int i = EVENT_QUEUE_SIZE; i > 0; i--) {
@@ -23,11 +24,11 @@ void test_event_queue_raise(void) {
   TEST_ASSERT_EQUAL(STATUS_CODE_RESOURCE_EXHAUSTED, prv_raise_event(0));
 
   Event e;
-  uint16_t i = 1;  // Start at 1 since the insertion of 0 should've failed
+  uint16_t i = EVENT_QUEUE_SIZE;
   while (status_ok(event_process(&e))) {
     TEST_ASSERT_EQUAL(i, e.id);
     TEST_ASSERT_EQUAL(i * 100, e.data);
-    i++;
+    i--;
   }
 
   TEST_ASSERT_OK(prv_raise_event(5));
@@ -35,6 +36,38 @@ void test_event_queue_raise(void) {
 
   TEST_ASSERT_EQUAL(5, e.id);
   TEST_ASSERT_EQUAL(5 * 100, e.data);
+
+  TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, event_process(&e));
+}
+
+void test_event_queue_raise_priority(void) {
+  // Test each priority.
+  for (int i = NUM_EVENT_PRIORITIES - 1; i >= 0; i--) {
+    TEST_ASSERT_OK(event_raise_priority(i, i * 10, i * 100));
+  }
+
+  Event e;
+  uint16_t i = 0;
+  while (status_ok(event_process(&e))) {
+    TEST_ASSERT_EQUAL(i * 10, e.id);
+    TEST_ASSERT_EQUAL(i * 100, e.data);
+    i++;
+  }
+  TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, event_process(&e));
+
+  // Spot check.
+  TEST_ASSERT_OK(event_raise_priority(EVENT_PRIORITY_NORMAL, 1, 10));
+  TEST_ASSERT_OK(event_raise_priority(EVENT_PRIORITY_HIGHEST, 1, 11));
+  TEST_ASSERT_OK(event_process(&e));
+  TEST_ASSERT_EQUAL(1, e.id);
+  TEST_ASSERT_EQUAL(11, e.data);
+  TEST_ASSERT_OK(event_raise_priority(EVENT_PRIORITY_HIGHEST, 1, 12));
+  TEST_ASSERT_OK(event_process(&e));
+  TEST_ASSERT_EQUAL(1, e.id);
+  TEST_ASSERT_EQUAL(12, e.data);
+  TEST_ASSERT_OK(event_process(&e));
+  TEST_ASSERT_EQUAL(1, e.id);
+  TEST_ASSERT_EQUAL(10, e.data);
 
   TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, event_process(&e));
 }

--- a/libraries/x86/test/test_x86_cmd.c
+++ b/libraries/x86/test/test_x86_cmd.c
@@ -4,7 +4,7 @@
 #include "unity.h"
 #include "x86_cmd.h"
 
-static const char s_cmd[30];
+static char s_cmd[30];
 static size_t s_num_args;
 
 static void prv_handler(int client_fd, const char *cmd, const char *args[], size_t num_args,

--- a/projects/driver_controls/src/drive_output.c
+++ b/projects/driver_controls/src/drive_output.c
@@ -14,7 +14,7 @@ static void prv_watchdog_cb(SoftTimerID timer_id, void *context) {
   if (storage->watchdog != DRIVE_OUTPUT_VALID_WATCHDOG) {
     // Error - raise a warning, disable periodic drive storage
     soft_timer_cancel(storage->output_timer);
-    event_raise(storage->fault_event, 0);
+    event_raise_priority(EVENT_PRIORITY_HIGHEST, storage->fault_event, 0);
   }
 
   // Reset watchdog


### PR DESCRIPTION
This change make the previously priority queue based `event_queue` module into a tiered priority FIFO queue.

The new behavior is as follows:
- `event_raise` is now just a FIFO of `NORMAL` priority.
- `event_raise_priority` allows events to be enqueued into one of five different priority FIFOs: `LOWEST, LOW, NORMAL, HIGH, HIGHEST`.
- `event_process` extracts an event from the highest priority FIFO that contains an event.
- `event_queue_init` is unchanged in it's behavior.

This has affected a single test which is updated with a fix.

It should be noted that CAN should be modified to allow events to be raised into a selected priority of event queue not just the `NORMAL` level (alternatively `HIGH` by default maybe?). This requires widespread changes to lots of locations as `CANSettings` structs across the codebase will need updating. I propose doing this in a separate change. The queue project may also require updates. 

Other than this it appears all uses of event_queue are in projects which are not expecting specific priority queue behavior (i.e. they either expected a FIFO to start with or the tests behave normally with a single FIFO) . Chaos obviously being the exception that I am aware of. 
