### PR TITLE
ELEC-451: Fix bugs in charger found during integration attempt

### DIFF
--- a/projects/charger/inc/charger_can.h
+++ b/projects/charger/inc/charger_can.h
@@ -38,6 +38,9 @@ typedef struct ChargerCanTxDataImpl {
   uint16_t max_voltage;
   uint16_t max_current;
   uint8_t charging;
+  uint8_t reserved_1;
+  uint8_t reserved_2;
+  uint8_t reserved_3;
 } ChargerCanTxDataImpl;
 
 typedef union ChargerCanTxData {
@@ -49,6 +52,9 @@ typedef struct ChargerCanRxDataImpl {
   uint16_t voltage;
   uint16_t current;
   ChargerCanStatus status_flags;
+  uint8_t reserved_1;
+  uint8_t reserved_2;
+  uint8_t reserved_3;
 } ChargerCanRxDataImpl;
 
 typedef union ChargerControllerRxData {

--- a/projects/charger/src/charger_cfg.c
+++ b/projects/charger/src/charger_cfg.c
@@ -12,13 +12,11 @@
 #include "status.h"
 #include "uart.h"
 
-// TODO(ELEC-355): Fill in the pinouts.
-
 static CANSettings s_can_settings = {
   .device_id = SYSTEM_CAN_DEVICE_CHARGER,
   .bitrate = CAN_HW_BITRATE_250KBPS,
-  .tx = { 0, 0 },
-  .rx = { 0, 0 },
+  .tx = { GPIO_PORT_A, 12 },
+  .rx = { GPIO_PORT_A, 11 },
   .rx_event = CHARGER_EVENT_CAN_RX,
   .tx_event = CHARGER_EVENT_CAN_TX,
   .fault_event = CHARGER_EVENT_CAN_FAULT,
@@ -33,9 +31,9 @@ static UARTSettings s_uart_settings = {
   .baudrate = 115200,
   .rx_handler = NULL,
   .context = NULL,
-  .tx = { 0, 0 },
-  .rx = { 0, 0 },
-  .alt_fn = NUM_GPIO_ALTFNS,
+  .tx = { GPIO_PORT_B, 10 },
+  .rx = { GPIO_PORT_B, 11 },
+  .alt_fn = GPIO_ALTFN_4,
 };
 
 UARTSettings *charger_cfg_load_uart_settings(void) {
@@ -43,19 +41,19 @@ UARTSettings *charger_cfg_load_uart_settings(void) {
 }
 
 UARTPort charger_cfg_load_uart_port(void) {
-  return 0;
+  return UART_PORT_3;
 }
 
 GPIOAddress charger_cfg_load_charger_pin(void) {
-  return ((GPIOAddress){ 0, 0 });
+  return ((GPIOAddress){ GPIO_PORT_A, 15 });
 }
 
 static GenericCanNetwork s_can_storage;
 static GenericCanUart s_can_uart_storage;
 
 static ChargerSettings s_charger_settings = {
-  .max_voltage = 0,
-  .max_current = 0,
+  .max_voltage = 1512,  // 151.2 V
+  .max_current = 1224,  // 122.4 A
   .can = (GenericCan *)&s_can_storage,
   .can_uart = (GenericCan *)&s_can_uart_storage,
 };

--- a/projects/charger/src/charger_controller.c
+++ b/projects/charger/src/charger_controller.c
@@ -16,8 +16,8 @@
 
 #define CHARGER_PERIOD_US 1000000  // 1 Second as defined in datasheet.
 
-#define CHARGER_EXPECTED_RX_DLC 5
-#define CHARGER_EXPECTED_TX_DLC 5
+#define CHARGER_EXPECTED_RX_DLC 8
+#define CHARGER_EXPECTED_TX_DLC 8
 
 static ChargerStorage *s_storage;
 static CanInterval *s_interval;

--- a/projects/charger/src/main.c
+++ b/projects/charger/src/main.c
@@ -2,6 +2,7 @@
 #include <stdlib.h>
 
 #include "can.h"
+#include "can_interval.h"
 #include "charger_cfg.h"
 #include "charger_controller.h"
 #include "charger_fsm.h"
@@ -16,6 +17,15 @@
 #include "uart.h"
 #include "wait.h"
 
+static CANStorage s_can_storage;
+static CANRxHandler s_can_rx_handlers[CHARGER_CFG_NUM_CAN_RX_HANDLERS];
+static UARTStorage s_uart_storage;
+static ChargerCanStatus s_charger_status;
+static ChargerStorage s_charger_storage;
+static FSM s_charger_fsm;
+
+// TODO(ELEC-355): Add support for polling the ADC/PWM signal from the charging station.
+
 int main(void) {
   // Generic Libraries
   event_queue_init();
@@ -23,17 +33,15 @@ int main(void) {
   gpio_init();
   gpio_it_init();
   soft_timer_init();
+  can_interval_init();
 
   // CAN
   const CANSettings *can_settings = charger_cfg_load_can_settings();
-  CANStorage can_storage;
-  CANRxHandler can_rx_handlers[CHARGER_CFG_NUM_CAN_RX_HANDLERS];
-  can_init(can_settings, &can_storage, can_rx_handlers, CHARGER_CFG_NUM_CAN_RX_HANDLERS);
+  can_init(can_settings, &s_can_storage, s_can_rx_handlers, CHARGER_CFG_NUM_CAN_RX_HANDLERS);
 
   // UART
   UARTSettings *uart_settings = charger_cfg_load_uart_settings();
-  UARTStorage uart_storage;
-  uart_init(charger_cfg_load_uart_port(), uart_settings, &uart_storage);
+  uart_init(charger_cfg_load_uart_port(), uart_settings, &s_uart_storage);
 
   // Charger Cfg
   charger_cfg_init_settings();
@@ -44,16 +52,13 @@ int main(void) {
 
   // Charger Controller
   const ChargerSettings *charger_settings = charger_cfg_load_settings();
-  ChargerCanStatus charger_status;
-  ChargerStorage charger_storage;
-  charger_controller_init(&charger_storage, charger_settings, &charger_status);
+  charger_controller_init(&s_charger_storage, charger_settings, &s_charger_status);
 
   // Notify/Command
   notify_init(charger_settings->can, CHARGER_CFG_SEND_PERIOD_S, CHARGER_CFG_WATCHDOG_PERIOD_S);
 
   // FSM
-  FSM charger_fsm;
-  charger_fsm_init(&charger_fsm);
+  charger_fsm_init(&s_charger_fsm);
 
   StatusCode status = NUM_STATUS_CODES;
   Event e = { 0 };
@@ -62,15 +67,12 @@ int main(void) {
       status = event_process(&e);
 
       // All events are interrupt driven so it is safe to wait while the event_queue is empty.
-      // TODO(ELEC-355): This may change based on what happens with the charger pin work as it may
-      // be on an ADC/PWM Signal.
       if (status == STATUS_CODE_EMPTY) {
         wait();
-        // TODO(ELEC-355): Validate nothing gets stuck here.
       }
     } while (status != STATUS_CODE_OK);
 
-    fsm_process_event(&charger_fsm, &e);
+    fsm_process_event(&s_charger_fsm, &e);
     fsm_process_event(CAN_FSM, &e);
   }
 

--- a/projects/charger/test/test_charger_controller.c
+++ b/projects/charger/test/test_charger_controller.c
@@ -20,7 +20,7 @@
 #define TEST_CHARGER_MAX_VOLTAGE 100
 #define TEST_CHARGER_MAX_CURRENT 200
 
-#define TEST_CHARGER_EXPECTED_DLC 5
+#define TEST_CHARGER_EXPECTED_DLC 8
 // NOTE: the TX and RX used for these IDs are from the perspective of the charger that is being
 // mocked. Internally, the charger controller labels these the other way around!
 #define TEST_CHARGER_EXPECTED_TX_ID 0x18FF50E5


### PR DESCRIPTION
I found a few minor issues with the charger code in attempting to get it working. This PR fixes those. In particular there were a few oversights with uninitialized memory, or missing inits. Additionally adds configuration for pins. Also the DLC for the CAN message was wrong although it doesn't explain why the charger wasn't responding.