### PR TITLE
ELEC-432: Add debug LED wrapper

### DIFF
--- a/libraries/ms-helper/inc/debug_led.h
+++ b/libraries/ms-helper/inc/debug_led.h
@@ -1,0 +1,31 @@
+#pragma once
+// Wrapper for the controller board's debug LEDs
+// GPIO must be initialized.
+//
+// Assumes the LEDs are as follows:
+// Blue: PB5
+// Blue: PB4
+// Yellow: PB3
+// Red: PA15
+#include <stdbool.h>
+#include "gpio.h"
+#include "status.h"
+
+typedef enum {
+  DEBUG_LED_BLUE_A,
+  DEBUG_LED_BLUE_B,
+  DEBUG_LED_YELLOW,
+  DEBUG_LED_RED,
+  NUM_DEBUG_LEDS,
+} DebugLed;
+
+// Initializes the specified debug LED.
+// We configure the LED only if explicitly initialized
+// in case we're sharing the pin with something else.
+StatusCode debug_led_init(DebugLed led);
+
+// Sets the specified debug LED's state. It must have been initialized first.
+StatusCode debug_led_set_state(DebugLed led, bool on);
+
+// Toggles the specified debug LED's state. It must have been initialized first.
+StatusCode debug_led_toggle_state(DebugLed led);

--- a/libraries/ms-helper/src/debug_led.c
+++ b/libraries/ms-helper/src/debug_led.c
@@ -1,0 +1,25 @@
+#include "debug_led.h"
+
+static const GPIOAddress s_leds[NUM_DEBUG_LEDS] = {
+  [DEBUG_LED_BLUE_A] = { .port = GPIO_PORT_B, .pin = 5 },
+  [DEBUG_LED_BLUE_B] = { .port = GPIO_PORT_B, .pin = 4 },
+  [DEBUG_LED_YELLOW] = { .port = GPIO_PORT_B, .pin = 3 },
+  [DEBUG_LED_RED] = { .port = GPIO_PORT_A, .pin = 15 },
+};
+
+StatusCode debug_led_init(DebugLed led) {
+  const GPIOSettings led_settings = {
+    .direction = GPIO_DIR_OUT,
+    .state = GPIO_STATE_HIGH,
+  };
+  return gpio_init_pin(&s_leds[led], &led_settings);
+}
+
+StatusCode debug_led_set_state(DebugLed led, bool on) {
+  // Active-low LED
+  return gpio_set_state(&s_leds[led], (on) ? GPIO_STATE_LOW : GPIO_STATE_HIGH);
+}
+
+StatusCode debug_led_toggle_state(DebugLed led) {
+  return gpio_toggle_state(&s_leds[led]);
+}

--- a/projects/plutus/src/bps_heartbeat.c
+++ b/projects/plutus/src/bps_heartbeat.c
@@ -1,5 +1,6 @@
 #include "bps_heartbeat.h"
 #include "can_transmit.h"
+#include "debug_led.h"
 #include "log.h"
 #include "plutus_cfg.h"
 
@@ -9,13 +10,17 @@ static StatusCode prv_handle_heartbeat_ack(CANMessageID msg_id, uint16_t device,
   BpsHeartbeatStorage *storage = context;
 
   if (status != CAN_ACK_STATUS_OK) {
-    // Something bad happened - fault
+    // We missed an ACK - fault after some grace period
     storage->ack_fail_counter++;
+    debug_led_set_state(DEBUG_LED_YELLOW, false);
 
     if (storage->ack_fail_counter >= PLUTUS_CFG_HEARTBEAT_MAX_ACK_FAILS) {
       return bps_heartbeat_raise_fault(storage, BPS_HEARTBEAT_FAULT_SOURCE_ACK_TIMEOUT);
     }
-  } else if (status == CAN_ACK_STATUS_OK) {
+  } else if (num_remaining == 0) {
+    // Received all ACKs as expected
+    debug_led_set_state(DEBUG_LED_YELLOW, true);
+
     storage->ack_fail_counter = 0;
     return bps_heartbeat_clear_fault(storage, BPS_HEARTBEAT_FAULT_SOURCE_ACK_TIMEOUT);
   }
@@ -37,6 +42,7 @@ static StatusCode prv_handle_state(BpsHeartbeatStorage *storage) {
     LOG_DEBUG("fault: 0x%x\n", storage->fault_bitset);
   }
   CAN_TRANSMIT_BPS_HEARTBEAT(&ack_request, state);
+  debug_led_set_state(DEBUG_LED_RED, (state == EE_BPS_HEARTBEAT_STATE_FAULT));
 
   if (state == EE_BPS_HEARTBEAT_STATE_FAULT) {
     return sequenced_relay_set_state(storage->relay, EE_RELAY_STATE_OPEN);
@@ -62,6 +68,11 @@ StatusCode bps_heartbeat_init(BpsHeartbeatStorage *storage, SequencedRelayStorag
   // Assume things are okay until told otherwise?
   storage->fault_bitset = 0x00;
   storage->ack_fail_counter = 0;
+
+  // Turn the red LED on if we've faulted
+  debug_led_init(DEBUG_LED_RED);
+  // Turn the yellow LED on if we're receiving ACKs
+  debug_led_init(DEBUG_LED_YELLOW);
 
   return soft_timer_start_millis(storage->period_ms * BPS_HEARTBEAT_STARTUP_DELAY_MULTIPLIER,
                                  prv_periodic_heartbeat, storage, NULL);


### PR DESCRIPTION
Adds a wrapper for the controller board's debug LEDs.

Also adds an example use-case for Plutus. The red LED will turn on when faulting, and the yellow LED represents good ACKs.