### PR TITLE
ELEC-465: Fix hardfault bug in ADC

### DIFF
--- a/libraries/ms-common/src/stm32f0xx/adc.c
+++ b/libraries/ms-common/src/stm32f0xx/adc.c
@@ -37,6 +37,10 @@ static uint16_t prv_get_temp(uint16_t reading) {
 
 // Formula obtained from section 13.9 of the reference manual. Returns Vdda in mV
 static uint16_t prv_get_vdda(uint16_t reading) {
+  // To avoid dividing by zero faults:
+  if (!reading) {
+    return reading;
+  }
   uint16_t vrefint_cal = *(uint16_t *)VREFINT_CAL;
   reading = (3300 * vrefint_cal) / reading;
   return reading;


### PR DESCRIPTION
Fixes a bug that causes a hardfault in the ADC driver by dividing by 0 when converting.