### PR TITLE
ELEC-465: Make BPS Heartbeat a bitset

### DIFF
--- a/libraries/ms-helper/inc/exported_enums.h
+++ b/libraries/ms-helper/inc/exported_enums.h
@@ -80,10 +80,3 @@ typedef enum {
   EE_POWER_STATE_DRIVE,
   NUM_EE_POWER_STATES,
 } EEPowerState;
-
-// Used with the BPS heartbeat message
-typedef enum {
-  EE_BPS_HEARTBEAT_STATE_OK = 0,
-  EE_BPS_HEARTBEAT_STATE_FAULT,
-  NUM_EE_BPS_HEARTBEAT_STATES,
-} EEBpsHeartbeatState;

--- a/projects/chaos/src/bps_heartbeat.c
+++ b/projects/chaos/src/bps_heartbeat.c
@@ -33,12 +33,11 @@ static StatusCode prv_kick_watchdog(void) {
 static StatusCode prv_bps_rx(const CANMessage *msg, void *context, CANAckStatus *ack_reply) {
   (void)context;
   (void)ack_reply;
-  uint8_t state = 0;
-  CAN_UNPACK_BPS_HEARTBEAT(msg, &state);
-  if (state == EE_BPS_HEARTBEAT_STATE_FAULT) {
+  prv_kick_watchdog();
+  uint8_t bitset = 0;
+  CAN_UNPACK_BPS_HEARTBEAT(msg, &bitset);
+  if (bitset) {
     event_raise(CHAOS_EVENT_SEQUENCE_EMERGENCY, 0);
-  } else {
-    prv_kick_watchdog();
   }
   return STATUS_CODE_OK;
 }

--- a/projects/chaos/test/test_bps_heartbeat.c
+++ b/projects/chaos/test/test_bps_heartbeat.c
@@ -16,6 +16,7 @@
 #include "gpio.h"
 #include "interrupt.h"
 #include "misc.h"
+#include "ms_test_helpers.h"
 #include "soft_timer.h"
 #include "status.h"
 #include "test_helpers.h"
@@ -69,7 +70,7 @@ void test_bps_heartbeat_watchdog_kick(void) {
   StatusCode status = NUM_STATUS_CODES;
 
   // Auto Start
-  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_req, EE_BPS_HEARTBEAT_STATE_OK);
+  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_req, 0);
   // Send HB
   // TX
   do {
@@ -101,7 +102,7 @@ void test_bps_heartbeat_watchdog_kick(void) {
   delay_ms(BPS_HEARTBEAT_EXPECTED_PERIOD_MS / 2);
 
   // Send the HB again
-  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_req, EE_BPS_HEARTBEAT_STATE_OK);
+  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_req, 0);
   // Send HB
   // TX
   do {
@@ -141,7 +142,7 @@ void test_bps_heartbeat_watchdog_kick(void) {
   TEST_ASSERT_EQUAL(CHAOS_EVENT_SEQUENCE_EMERGENCY, e.id);
 
   // Verify that it auto restarts.
-  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_req, EE_BPS_HEARTBEAT_STATE_OK);
+  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_req, 0);
   // Send HB
   // TX
   do {
@@ -187,4 +188,12 @@ void test_bps_heartbeat_watchdog_timeout(void) {
   // Verify the watchdog is stopped after receiving the first time.
   delay_ms(BPS_HEARTBEAT_EXPECTED_PERIOD_MS + BPS_HEARTBEAT_EXPECTED_PERIOD_MS / 10);
   TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, event_process(&e));
+}
+
+void test_bps_heartbeat_fault(void) {
+  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_req, 0);
+  MS_TEST_HELPER_CAN_TX_RX_WITH_ACK(CHAOS_EVENT_CAN_TX, CHAOS_EVENT_CAN_RX);
+  Event e = { 0 };
+  TEST_ASSERT_OK(event_process(&e));
+  TEST_ASSERT_EQUAL(CHAOS_EVENT_SEQUENCE_EMERGENCY, e.id);
 }

--- a/projects/plutus/src/bps_heartbeat.c
+++ b/projects/plutus/src/bps_heartbeat.c
@@ -30,15 +30,10 @@ static StatusCode prv_handle_state(BpsHeartbeatStorage *storage) {
     .expected_bitset = storage->expected_bitset,
   };
 
-  // Only transmit state OK if we have no ongoing faults
-  EEBpsHeartbeatState state =
-      (storage->fault_bitset == 0x0) ? EE_BPS_HEARTBEAT_STATE_OK : EE_BPS_HEARTBEAT_STATE_FAULT;
-  if (state == EE_BPS_HEARTBEAT_STATE_FAULT) {
-    LOG_DEBUG("fault: 0x%x\n", storage->fault_bitset);
-  }
-  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_request, state);
+  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_request, storage->fault_bitset);
 
-  if (state == EE_BPS_HEARTBEAT_STATE_FAULT) {
+  if (storage->fault_bitset) {
+    LOG_DEBUG("fault: 0x%x\n", storage->fault_bitset);
     return sequenced_relay_set_state(storage->relay, EE_RELAY_STATE_OPEN);
   }
 


### PR DESCRIPTION
Turns the state field in BPS_HEARTBEAT into a bitset. I'll need to update codegen before merging this as the bitfield is only 8 bits which we can in theory overflow.