### PR TITLE
ELEC-482: Fix soft timer race in stm32f0xx

### DIFF
--- a/libraries/ms-common/inc/soft_timer.h
+++ b/libraries/ms-common/inc/soft_timer.h
@@ -6,6 +6,8 @@
 
 #include "status.h"
 
+#define SOFT_TIMER_MIN_TIME_US 50
+
 #define SOFT_TIMER_MAX_TIMERS 25
 #define SOFT_TIMER_INVALID_TIMER (SOFT_TIMER_MAX_TIMERS)
 

--- a/libraries/ms-common/src/stm32f0xx/soft_timer.c
+++ b/libraries/ms-common/src/stm32f0xx/soft_timer.c
@@ -212,8 +212,8 @@ static void prv_update_timer(void) {
   // and reenable compares. In the case where there aren't any timers registered, the compare
   // channel is disabled until a new timer is added.
   if (s_timers.head != NULL) {
-    TIM_SetCompare1(TIM2, MAX(s_timers.head->expiry_us, 
-          TIM_GetCounter(TIM2) + SOFT_TIMER_MIN_TIME_US);
+    TIM_SetCompare1(TIM2,
+                    MAX(s_timers.head->expiry_us, TIM_GetCounter(TIM2) + SOFT_TIMER_MIN_TIME_US));
     TIM_CCxCmd(TIM2, TIM_Channel_1, TIM_CCx_Enable);
   }
 }

--- a/libraries/ms-common/src/stm32f0xx/soft_timer.c
+++ b/libraries/ms-common/src/stm32f0xx/soft_timer.c
@@ -6,6 +6,7 @@
 #include "soft_timer.h"
 #include <string.h>
 #include "critical_section.h"
+#include "misc.h"
 #include "objpool.h"
 #include "stm32f0xx.h"
 
@@ -211,7 +212,8 @@ static void prv_update_timer(void) {
   // and reenable compares. In the case where there aren't any timers registered, the compare
   // channel is disabled until a new timer is added.
   if (s_timers.head != NULL) {
-    TIM_SetCompare1(TIM2, s_timers.head->expiry_us);
+    TIM_SetCompare1(TIM2, MAX(s_timers.head->expiry_us, 
+          TIM_GetCounter(TIM2) + SOFT_TIMER_MIN_TIME_US);
     TIM_CCxCmd(TIM2, TIM_Channel_1, TIM_CCx_Enable);
   }
 }

--- a/libraries/ms-common/src/x86/soft_timer.c
+++ b/libraries/ms-common/src/x86/soft_timer.c
@@ -83,6 +83,9 @@ void soft_timer_init(void) {
 
 StatusCode soft_timer_start(uint32_t duration_us, SoftTimerCallback callback, void *context,
                             SoftTimerID *timer_id) {
+  if (duration_us < SOFT_TIMER_MIN_TIME_US) {
+    return status_msg(STATUS_CODE_INVALID_ARGS, "Soft timer too short!");
+  }
   // Start a critical section to prevent this section from being broken.
   const bool critical = critical_section_start();
   for (uint32_t i = 0; i < SOFT_TIMER_MAX_TIMERS; i++) {

--- a/libraries/ms-common/test/test_soft_timer.c
+++ b/libraries/ms-common/test/test_soft_timer.c
@@ -122,7 +122,7 @@ void test_soft_timer_cancelled_timer(void) {
   TEST_ASSERT_OK(ret);
   TEST_ASSERT_NOT_EQUAL(SOFT_TIMER_INVALID_TIMER, id_long);
 
-  ret = soft_timer_start(10, prv_timeout_cb, (void *)&cb_id_short, &id_short);
+  ret = soft_timer_start(SOFT_TIMER_MIN_TIME_US, prv_timeout_cb, (void *)&cb_id_short, &id_short);
   TEST_ASSERT_OK(ret);
   TEST_ASSERT_NOT_EQUAL(SOFT_TIMER_INVALID_TIMER, id_short);
 
@@ -198,4 +198,9 @@ void test_soft_timer_exhausted(void) {
   }
 
   TEST_ASSERT_FALSE(soft_timer_inuse());
+}
+
+void test_soft_timer_too_short(void) {
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS,
+                    soft_timer_start(SOFT_TIMER_MIN_TIME_US - 1, prv_timeout_cb, NULL, NULL));
 }


### PR DESCRIPTION
- Wrap start/cancel in critical sections
- Require minimum time to start
- Don't call prv_update in the start timer 
- Require minimum period between interrupts