### PR TITLE
ELEC-504: Increase HB Reliability

### DIFF
--- a/libraries/ms-common/inc/can_ack.h
+++ b/libraries/ms-common/inc/can_ack.h
@@ -19,7 +19,7 @@
 
 // ACK timeout: Should account for transit and computation time
 // Note that this timeout is currently an arbitrary value, but should be minimized.
-#define CAN_ACK_TIMEOUT_MS 25
+#define CAN_ACK_TIMEOUT_MS 50
 #define CAN_ACK_MAX_REQUESTS 10
 
 // Converts devices IDs to their bitset form. Populate ACK request bitsets using this.

--- a/projects/chaos/inc/powertrain_heartbeat.h
+++ b/projects/chaos/inc/powertrain_heartbeat.h
@@ -13,6 +13,7 @@
 #include "event_queue.h"
 #include "status.h"
 
+#define POWERTRAIN_HEARTBEAT_SEQUENTIAL_PACKETS 5
 #define POWERTRAIN_HEARTBEAT_MS 1000
 #define POWERTRAIN_HEARTBEAT_WATCHDOG_MS 4100
 

--- a/projects/chaos/src/powertrain_heartbeat.c
+++ b/projects/chaos/src/powertrain_heartbeat.c
@@ -43,7 +43,6 @@ static void prv_hb_watchdog(SoftTimerID timer_id, void *context) {
 }
 
 static void prv_kick_watchdog(void) {
-  LOG_DEBUG("Kicked\n");
   if (s_watchdog_id != SOFT_TIMER_INVALID_TIMER) {
     soft_timer_cancel(s_watchdog_id);
     s_watchdog_id = SOFT_TIMER_INVALID_TIMER;
@@ -59,7 +58,6 @@ static StatusCode prv_ack_cb(CANMessageID id, uint16_t device, CANAckStatus stat
   (void)device;
   (void)context;
   (void)status;
-  LOG_DEBUG("Ack %d\n", num_remaining);
   if (num_remaining == 0) {
     prv_kick_watchdog();
   }
@@ -77,11 +75,10 @@ static void prv_send_hb_request(SoftTimerID timer_id, void *context) {
         SYSTEM_CAN_DEVICE_PLUTUS, SYSTEM_CAN_DEVICE_PLUTUS_SLAVE, SYSTEM_CAN_DEVICE_DRIVER_CONTROLS,
         SYSTEM_CAN_DEVICE_MOTOR_CONTROLLER),
   };
-  CAN_TRANSMIT_POWERTRAIN_HEARTBEAT(&ack_req);
   for (size_t i = 0; i < POWERTRAIN_HEARTBEAT_SEQUENTIAL_PACKETS - 1; i++) {
     CAN_TRANSMIT_POWERTRAIN_HEARTBEAT(NULL);
   }
-  LOG_DEBUG("sent\n");
+  CAN_TRANSMIT_POWERTRAIN_HEARTBEAT(&ack_req);
   soft_timer_start_millis(POWERTRAIN_HEARTBEAT_MS, prv_send_hb_request, NULL, &s_interval_id);
 }
 

--- a/projects/chaos/src/powertrain_heartbeat.c
+++ b/projects/chaos/src/powertrain_heartbeat.c
@@ -43,6 +43,7 @@ static void prv_hb_watchdog(SoftTimerID timer_id, void *context) {
 }
 
 static void prv_kick_watchdog(void) {
+  LOG_DEBUG("Kicked\n");
   if (s_watchdog_id != SOFT_TIMER_INVALID_TIMER) {
     soft_timer_cancel(s_watchdog_id);
     s_watchdog_id = SOFT_TIMER_INVALID_TIMER;
@@ -58,6 +59,7 @@ static StatusCode prv_ack_cb(CANMessageID id, uint16_t device, CANAckStatus stat
   (void)device;
   (void)context;
   (void)status;
+  LOG_DEBUG("Ack\n");
   if (num_remaining == 0) {
     prv_kick_watchdog();
   }
@@ -76,6 +78,9 @@ static void prv_send_hb_request(SoftTimerID timer_id, void *context) {
         SYSTEM_CAN_DEVICE_MOTOR_CONTROLLER),
   };
   CAN_TRANSMIT_POWERTRAIN_HEARTBEAT(&ack_req);
+  for (size_t i = 0; i < POWERTRAIN_HEARTBEAT_SEQUENTIAL_PACKETS - 1; i++) {
+    CAN_TRANSMIT_POWERTRAIN_HEARTBEAT(NULL);
+  }
   soft_timer_start_millis(POWERTRAIN_HEARTBEAT_MS, prv_send_hb_request, NULL, &s_interval_id);
 }
 

--- a/projects/chaos/src/powertrain_heartbeat.c
+++ b/projects/chaos/src/powertrain_heartbeat.c
@@ -59,7 +59,7 @@ static StatusCode prv_ack_cb(CANMessageID id, uint16_t device, CANAckStatus stat
   (void)device;
   (void)context;
   (void)status;
-  LOG_DEBUG("Ack\n");
+  LOG_DEBUG("Ack %d\n", num_remaining);
   if (num_remaining == 0) {
     prv_kick_watchdog();
   }
@@ -81,6 +81,7 @@ static void prv_send_hb_request(SoftTimerID timer_id, void *context) {
   for (size_t i = 0; i < POWERTRAIN_HEARTBEAT_SEQUENTIAL_PACKETS - 1; i++) {
     CAN_TRANSMIT_POWERTRAIN_HEARTBEAT(NULL);
   }
+  LOG_DEBUG("sent\n");
   soft_timer_start_millis(POWERTRAIN_HEARTBEAT_MS, prv_send_hb_request, NULL, &s_interval_id);
 }
 

--- a/projects/chaos/test/test_powertrain_heartbeat.c
+++ b/projects/chaos/test/test_powertrain_heartbeat.c
@@ -62,7 +62,6 @@ void test_powertrain_heartbeat_watchdog(void) {
   for (size_t i = 0; i < POWERTRAIN_HEARTBEAT_SEQUENTIAL_PACKETS *
                              TEST_POWERTRAIN_HEARTBEAT_CAN_EVENTS_PER_ACK * 5;
        i++) {
-    LOG_DEBUG("Looped %ld\n", i);
     MS_TEST_HELPER_AWAIT_EVENT(e);
     TEST_ASSERT_TRUE(can_process_event(&e));
   }

--- a/projects/plutus/inc/bps_heartbeat.h
+++ b/projects/plutus/inc/bps_heartbeat.h
@@ -4,6 +4,8 @@
 #include "exported_enums.h"
 #include "sequenced_relay.h"
 
+#define BPS_HEARTBEAT_SEQUENTIAL_PACKETS 5
+
 // Arbitrary multiplier to the heartbeat period for initial startup delay
 // This is necessary because Chaos takes some time to initialize before it can ACK
 #define BPS_HEARTBEAT_STARTUP_DELAY_MULTIPLIER 5

--- a/projects/plutus/src/bps_heartbeat.c
+++ b/projects/plutus/src/bps_heartbeat.c
@@ -37,6 +37,9 @@ static StatusCode prv_handle_state(BpsHeartbeatStorage *storage) {
 
   // Only transmit state OK if we have no ongoing faults
   CAN_TRANSMIT_BPS_HEARTBEAT(&ack_request, storage->fault_bitset);
+  for (uint8_t i = 0; i < BPS_HEARTBEAT_SEQUENTIAL_PACKETS - 1; i++) {
+    CAN_TRANSMIT_BPS_HEARTBEAT(NULL, storage->fault_bitset);
+  }
   debug_led_set_state(DEBUG_LED_RED, (storage->fault_bitset != EE_BPS_HEARTBEAT_STATE_OK));
 
   if (storage->fault_bitset != EE_BPS_HEARTBEAT_STATE_OK) {

--- a/projects/plutus/src/bps_heartbeat.c
+++ b/projects/plutus/src/bps_heartbeat.c
@@ -36,10 +36,10 @@ static StatusCode prv_handle_state(BpsHeartbeatStorage *storage) {
   };
 
   // Only transmit state OK if we have no ongoing faults
-  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_request, storage->fault_bitset);
   for (uint8_t i = 0; i < BPS_HEARTBEAT_SEQUENTIAL_PACKETS - 1; i++) {
     CAN_TRANSMIT_BPS_HEARTBEAT(NULL, storage->fault_bitset);
   }
+  CAN_TRANSMIT_BPS_HEARTBEAT(&ack_request, storage->fault_bitset);
   debug_led_set_state(DEBUG_LED_RED, (storage->fault_bitset != EE_BPS_HEARTBEAT_STATE_OK));
 
   if (storage->fault_bitset != EE_BPS_HEARTBEAT_STATE_OK) {


### PR DESCRIPTION
Nate suggested we use multiple sends of a Heartbeat sequentially on each to form a packet on each send. By having 5-10 of the same message in a row this decreases the chance that noise or a dropped packet will clobber the heartbeat and result in a fault. To do so we send the message multiple times without registering an ACK for any of the sends other than the last. This works because the ACK gets registered for a message but all the sends and receives map to an ACK by its ID only. As a result, if a device responds to at least one or more of the messages it is counted. This should be much more reliable.