### PR TITLE
ELEC-524: Add motor controller reset handlers

### DIFF
--- a/projects/mc_interface/inc/motor_controller.h
+++ b/projects/mc_interface/inc/motor_controller.h
@@ -97,3 +97,6 @@ StatusCode motor_controller_set_throttle(MotorControllerStorage *controller, int
 
 // Switch the motor controllers to cruise control
 StatusCode motor_controller_set_cruise(MotorControllerStorage *controller, int16_t speed_cms);
+
+// Trigger a reset of all the motor controllers
+StatusCode motor_controller_trigger_reset(MotorControllerStorage *storage);

--- a/projects/mc_interface/src/motor_controller.c
+++ b/projects/mc_interface/src/motor_controller.c
@@ -188,3 +188,22 @@ StatusCode motor_controller_set_cruise(MotorControllerStorage *controller, int16
 
   return STATUS_CODE_OK;
 }
+
+StatusCode motor_controller_trigger_reset(MotorControllerStorage *storage) {
+  GenericCanMsg msg = { .dlc = 8, .extended = false };
+
+  for (size_t i = 0; i < NUM_MOTOR_CONTROLLERS; i++) {
+    WaveSculptorCanId can_id = {
+      .device_id = storage->settings.ids[i].interface,
+      .msg_id = WAVESCULPTOR_CMD_ID_RESET,
+    };
+    msg.id = can_id.raw;
+
+    WaveSculptorCanData can_data = { 0 };
+    msg.data = can_data.raw;
+
+    status_ok_or_return(generic_can_tx(storage->settings.motor_can, &msg));
+  }
+
+  return STATUS_CODE_OK;
+}


### PR DESCRIPTION
This adds reset handlers on the system CAN bus to allow for resetting
the motor controllers.

This is waiting on codegen changes to be merged so this build doesn't
fail, as it depends on a new `enum` message id.