### PR TITLE
ELEC-534: Add CAN dump parser script

### DIFF
--- a/projects/can_dump/scripts/README.md
+++ b/projects/can_dump/scripts/README.md
@@ -1,0 +1,29 @@
+# CAN dump
+
+## Setup
+
+You may wish to setup `udev` rules in order to make finding the Xbee device 
+easier.
+
+Under `/etc/udev/rules.d/`, create a file which will contain the `udev` rule, 
+called `/etc/udev/rules.d/10-xbee.rules`. Then add the following:
+
+```
+SUBSYSTEM=="tty", ATTRS{idVendor}=="0403", ATTRS{idProduct}=="6015", SYMLINK+="ttyXbee", MODE="0666"
+```
+
+## Usage
+
+```bash
+# Install requirements.txt (from a virtualenv or something)
+pip install -r requirements.txt
+
+# Run the script from the root of the firmware repository
+python projects/can_dump/scripts/dump_system.py /dev/ttyXbee
+
+# Messages can be filtered by CAN id using the -m flag
+python projects/can_dump/scripts/dump_system.py /dev/ttyXbee -m32
+
+# The log data can be parsed using the parse_data.py script
+python projects/can_dump/script/parse_data.py --file='logs/system_can_2018-07-20 08:12:22.467099.log'
+```

--- a/projects/can_dump/scripts/can_message.py
+++ b/projects/can_dump/scripts/can_message.py
@@ -1,0 +1,104 @@
+import binascii
+import struct
+
+DATA_POWER_STATE = ['idle', 'charge', 'drive']
+LIGHTS_ID_NAME = [
+    'High beams', 'Low beams', 'DRL', 'Brakes',
+    'Left Turn', 'Right Turn', 'Hazards', 'BPS Strobe'
+]
+
+def data_relay(state):
+    """Relay state data format"""
+    return 'close' if state else 'open'
+
+def data_power_state(state):
+    """Power state data format"""
+    return DATA_POWER_STATE[state]
+
+def data_lights_state(light_id, state):
+    """Lights state data format"""
+    id_name = LIGHTS_ID_NAME[light_id]
+    state_name = 'on' if state else 'off'
+    return '{}: {}'.format(id_name, state_name)
+
+def data_battery_vt(module, voltage, temperature):
+    """Battery V/T data format"""
+    return 'C{}: {:.1f}mV aux {:.1f}mV'.format(module, voltage / 10, temperature / 10)
+
+def data_battery_voltage_current(voltage, current):
+    """Battery total voltage/current data format"""
+    return '{:.4f}V {:.4f}A'.format(voltage / 10000, current / 1000000)
+
+def data_dump(*args):
+    """Generic data dump format"""
+    return ' '.join(['{}'.format(arg) for arg in args])
+
+# Name, struct format, data format 0, ...
+MESSAGE_LOOKUP = {
+    0: ('BPS Heartbeat', '<B', data_dump),
+    1: ('Chaos Fault', '<B', data_dump),
+    2: ('Battery relay (Main)', '<B', data_relay),
+    3: ('Battery relay (Slave)', '<B', data_relay),
+    4: ('Motor relay', '<B', data_relay),
+    5: ('Solar relay (Rear)', '<B', data_relay),
+    6: ('Solar relay (Front)', '<B', data_relay),
+    7: ('Power state', '<B', data_power_state),
+    8: ('Chaos Heartbeat', '', data_dump),
+    18: ('Drive Output', '<hhhh', data_dump),
+    19: ('Cruise Target', '<B', data_dump),
+    23: ('Lights Sync', '', data_dump),
+    24: ('Lights State', '<BB', data_lights_state),
+    26: ('Charger state', '<B', data_dump),
+    27: ('Charger relay', '<B', data_relay),
+    32: ('Battery V/T', '<HHH', data_battery_vt),
+    33: ('Battery Voltage/Current', '<ii', data_battery_voltage_current),
+    35: ('Motor Bus Measurement', '<hhhh', data_dump),
+    36: ('Motor Velocity', '<hh', data_dump),
+    43: ('Aux & DC/DC V/C', '<HHHH', data_dump),
+}
+
+
+class CanMessage:
+  def __init__(self, can_id, can_data):
+    self._can_id = can_id
+    self._can_data = can_data
+
+  def parse(self):
+    # System CAN ID format:
+    # [0:3] Source ID
+    # [4] Message Type (ACK/DATA)
+    # [5:10] Message ID
+    source_id = self._can_id & 0xf
+    msg_type = (self._can_id >> 4) & 0x1
+    msg_id = (self._can_id >> 5) & 0x3f
+
+    # 2018-07-18 09:07:46,826,0x401,0x1f001c98c365,6
+    # 0x401: 0b00000|100000|0|0001
+    # source_id: 1 (PLUTUS)
+    # type: 0 (CAN_MSG_TYPE_DATA)
+
+    # 0x13: 0b00000000000|1|0011
+    #  print('source_id: ' + str(source_id))
+    #  print('msg_id: ' + str(msg_id))
+
+    msg_type_name = 'ACK' if msg_type == 1 else 'DATA'
+
+    if msg_id in MESSAGE_LOOKUP:
+        name, fmt, data_fn = MESSAGE_LOOKUP[msg_id]
+        if fmt:
+            try:
+                unpacked_data = struct.unpack(fmt, self._can_data)
+            except struct.error:
+                print('Invalid {}'.format(msg_id))
+                return
+        else:
+            unpacked_data = []
+
+        if msg_type_name == 'ACK':
+            print('{} ACK from {}'.format(name, source_id))
+        else:
+            print('{}: {}'.format(name, data_fn(*unpacked_data)))
+    else:
+        # Unrecognized message
+        print('{} from {} ({}): 0x{}'.format(msg_id, source_id, msg_type_name,
+                                             binascii.hexlify(self._can_data).decode('ascii')))

--- a/projects/can_dump/scripts/can_message.py
+++ b/projects/can_dump/scripts/can_message.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""A CAN message parsing utility module
-"""
+"""A CAN message parsing utility module"""
 import binascii
 import struct
 

--- a/projects/can_dump/scripts/can_message.py
+++ b/projects/can_dump/scripts/can_message.py
@@ -65,6 +65,9 @@ class CanMessage:
 
     This is simply a CAN ID and the CAN data
 
+    Args:
+        can_id: Raw standard CAN ID.
+        can_data: Message data. Up to 8 bytes.
     """
     def __init__(self, can_id, can_data):
         self._can_id = can_id

--- a/projects/can_dump/scripts/dump_system.py
+++ b/projects/can_dump/scripts/dump_system.py
@@ -2,7 +2,6 @@
 """ Dumps CAN information from SocketCAN/serial """
 import argparse
 from abc import abstractmethod
-import binascii
 import datetime
 import logging
 import os

--- a/projects/can_dump/scripts/dump_system.py
+++ b/projects/can_dump/scripts/dump_system.py
@@ -12,101 +12,7 @@ import serial
 import serial.tools.list_ports
 from cobs import cobs
 
-DATA_POWER_STATE = ['idle', 'charge', 'drive']
-LIGHTS_ID_NAME = [
-    'High beams', 'Low beams', 'DRL', 'Brakes',
-    'Left Turn', 'Right Turn', 'Hazards', 'BPS Strobe'
-]
-
-def data_relay(state):
-    """Relay state data format"""
-    return 'close' if state else 'open'
-
-def data_power_state(state):
-    """Power state data format"""
-    return DATA_POWER_STATE[state]
-
-def data_lights_state(light_id, state):
-    """Lights state data format"""
-    id_name = LIGHTS_ID_NAME[light_id]
-    state_name = 'on' if state else 'off'
-    return '{}: {}'.format(id_name, state_name)
-
-def data_battery_vt(module, voltage, temperature):
-    """Battery V/T data format"""
-    return 'C{}: {:.1f}mV aux {:.1f}mV'.format(module, voltage / 10, temperature / 10)
-
-def data_battery_voltage_current(voltage, current):
-    """Battery total voltage/current data format"""
-    return '{:.4f}V {:.4f}A'.format(voltage / 10000, current / 1000000)
-
-def data_dump(*args):
-    """Generic data dump format"""
-    return ' '.join(['{}'.format(arg) for arg in args])
-
-# Name, struct format, data format 0, ...
-MESSAGE_LOOKUP = {
-    0: ('BPS Heartbeat', '<B', data_dump),
-    1: ('Chaos Fault', '<B', data_dump),
-    2: ('Battery relay (Main)', '<B', data_relay),
-    3: ('Battery relay (Slave)', '<B', data_relay),
-    4: ('Motor relay', '<B', data_relay),
-    5: ('Solar relay (Rear)', '<B', data_relay),
-    6: ('Solar relay (Front)', '<B', data_relay),
-    7: ('Power state', '<B', data_power_state),
-    8: ('Chaos Heartbeat', '', data_dump),
-    18: ('Drive Output', '<hhhh', data_dump),
-    19: ('Cruise Target', '<B', data_dump),
-    23: ('Lights Sync', '', data_dump),
-    24: ('Lights State', '<BB', data_lights_state),
-    26: ('Charger state', '<B', data_dump),
-    27: ('Charger relay', '<B', data_relay),
-    32: ('Battery V/T', '<HHH', data_battery_vt),
-    33: ('Battery Voltage/Current', '<ii', data_battery_voltage_current),
-    35: ('Motor Bus Measurement', '<hhhh', data_dump),
-    36: ('Motor Velocity', '<hh', data_dump),
-    43: ('Aux & DC/DC V/C', '<HHHH', data_dump),
-}
-
-def parse_msg(can_id, data):
-    """Parses and prints a system CAN message.
-
-    Args:
-        can_id: Raw standard CAN ID.
-        data: Message data. Up to 8 bytes.
-
-    Returns:
-        None
-    """
-    # System CAN ID format:
-    # [0:3] Source ID
-    # [4] Message Type (ACK/DATA)
-    # [5:10] Message ID
-    source_id = can_id & 0xf
-    msg_type = (can_id >> 4) & 0x1
-    msg_id = (can_id >> 5) & 0x3f
-
-    msg_type_name = 'ACK' if msg_type == 1 else 'DATA'
-
-    if msg_id in MESSAGE_LOOKUP:
-        name, fmt, data_fn = MESSAGE_LOOKUP[msg_id]
-        if fmt:
-            try:
-                unpacked_data = struct.unpack(fmt, data)
-            except struct.error:
-                print('Invalid {}'.format(msg_id))
-                return
-        else:
-            unpacked_data = []
-
-        if msg_type_name == 'ACK':
-            print('{} ACK from {}'.format(name, source_id))
-        else:
-            print('{}: {}'.format(name, data_fn(*unpacked_data)))
-    else:
-        # Unrecognized message
-        print('{} from {} ({}): 0x{}'.format(msg_id, source_id, msg_type_name,
-                                             binascii.hexlify(data).decode('ascii')))
+from can_message import CanMessage
 
 def select_device():
     """User-provided serial device selector.
@@ -169,7 +75,8 @@ class CanDataSource:
             # CAN ID, data, DLC
             can_id, data = self.get_packet()
             if can_id not in self.masked:
-                parse_msg(can_id, data)
+                can_msg = CanMessage(can_id, data)
+                can_msg.parse()
 
             logging.info('{},{},{}'.format(can_id, data, len(data))) #pylint: disable=logging-format-interpolation
 

--- a/projects/can_dump/scripts/parse_data.py
+++ b/projects/can_dump/scripts/parse_data.py
@@ -10,11 +10,10 @@ def parse_data(file_name):
     log_reader = csv.reader(open(file_name, 'r'), delimiter=',')
 
     for row in log_reader:
-        # data is logged in the format (timestamp, (can_id, data, len(data)))
+        # Data is logged in the format (timestamp, (can_id, data, len(data))).
         timestamp = row[0]
         can_id = int(row[1], 16)
         can_data = int(row[2], 16)
-
         data_len = int(row[3])
 
         msg = CanMessage(can_id, can_data.to_bytes(data_len, 'big'))

--- a/projects/can_dump/scripts/parse_data.py
+++ b/projects/can_dump/scripts/parse_data.py
@@ -1,35 +1,36 @@
+"""Parses CAN logs created by the system dump tool
+"""
 import argparse
-import binascii
 import csv
 
 from can_message import CanMessage
 
-def fix_hex(hex_value):
-  # Takes a hex string in the form '0xaabbccdd' and
-  # 1. Strips off the 0x
-  # 2.
-  return
-
 def parse_data(file_name):
-  log_reader = csv.reader(open(file_name, 'r'), delimiter=',')
+    """Read the CSV data and parse it"""
+    log_reader = csv.reader(open(file_name, 'r'), delimiter=',')
 
-  for row in log_reader:
-    # data is logged in the format (timestamp, (can_id, data, len(data)))
-    timestamp = 0
-    can_id = int(row[1], 16)
-    can_data = int(row[2], 16)
+    for row in log_reader:
+        # data is logged in the format (timestamp, (can_id, data, len(data)))
+        timestamp = row[0]
+        can_id = int(row[1], 16)
+        can_data = int(row[2], 16)
 
-    data_len = int(row[3])
+        data_len = int(row[3])
 
-    msg = CanMessage(can_id, can_data.to_bytes(data_len, 'big'))
+        msg = CanMessage(can_id, can_data.to_bytes(data_len, 'big'))
 
-    msg.parse()
+        print(timestamp)
+        msg.parse()
+
+def main():
+    """Main entry point"""
+    parser = argparse.ArgumentParser(description='Parsing CAN log data')
+    parser.add_argument('--file', required=True)
+
+    args = parser.parse_args()
+
+    parse_data(args.file)
 
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser(description='Parsing CAN log data')
-  parser.add_argument('--file', required=True)
-
-  args = parser.parse_args()
-
-  parse_data(args.file)
+    main()

--- a/projects/can_dump/scripts/parse_data.py
+++ b/projects/can_dump/scripts/parse_data.py
@@ -1,0 +1,35 @@
+import argparse
+import binascii
+import csv
+
+from can_message import CanMessage
+
+def fix_hex(hex_value):
+  # Takes a hex string in the form '0xaabbccdd' and
+  # 1. Strips off the 0x
+  # 2.
+  return
+
+def parse_data(file_name):
+  log_reader = csv.reader(open(file_name, 'r'), delimiter=',')
+
+  for row in log_reader:
+    # data is logged in the format (timestamp, (can_id, data, len(data)))
+    timestamp = 0
+    can_id = int(row[1], 16)
+    can_data = int(row[2], 16)
+
+    data_len = int(row[3])
+
+    msg = CanMessage(can_id, can_data.to_bytes(data_len, 'big'))
+
+    msg.parse()
+
+
+if __name__ == '__main__':
+  parser = argparse.ArgumentParser(description='Parsing CAN log data')
+  parser.add_argument('--file', required=True)
+
+  args = parser.parse_args()
+
+  parse_data(args.file)


### PR DESCRIPTION
I'm waiting for the improvements to the CAN script to go in before I rebase
these changes on top of that. However, I'll put this up for review for now,
and then I'll rebase once those changes get in.

This adds a `parse_data.py` script that parses the logged data.

In addition, I've refactored out the CAN parsing logic out of the main 
`dump_system.py` script, and creates a `can_message.py` file that 
contains all that logic. This allows the `parse_data.py` script to share
the code.