### PR TITLE
ELEC-546: Fix dump system log filenames

### DIFF
--- a/projects/can_dump/scripts/dump_system.py
+++ b/projects/can_dump/scripts/dump_system.py
@@ -157,7 +157,8 @@ def main():
     parser.add_argument('device', help='Serial device or "slcan0"')
     args = parser.parse_args()
 
-    log_file = '{}/system_can_{}.log'.format(args.log_dir, datetime.datetime.now().strftime('%Y-%m-%d %H.%M.%S.%f'))
+    date_formatted = datetime.datetime.now().strftime('%Y-%m-%d %H.%M.%S.%f')
+    log_file = '{}/system_can_{}.log'.format(args.log_dir, date_formatted)
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s,%(message)s', filename=log_file)
 

--- a/projects/can_dump/scripts/dump_system.py
+++ b/projects/can_dump/scripts/dump_system.py
@@ -157,7 +157,7 @@ def main():
     parser.add_argument('device', help='Serial device or "slcan0"')
     args = parser.parse_args()
 
-    log_file = '{}/system_can_{}.log'.format(args.log_dir, datetime.datetime.now())
+    log_file = '{}/system_can_{}.log'.format(args.log_dir, datetime.datetime.now().strftime('%Y-%m-%d %H.%M.%S.%f'))
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
     logging.basicConfig(level=logging.DEBUG, format='%(asctime)s,%(message)s', filename=log_file)
 


### PR DESCRIPTION
This fixes the filename format string so that running on Windows doesn't 
create files with invalid filenames.

Pretty trivial change...