### PR TITLE
ELEC-535: Quote dump_system log timestamps

### DIFF
--- a/projects/can_dump/scripts/dump_system.py
+++ b/projects/can_dump/scripts/dump_system.py
@@ -160,7 +160,7 @@ def main():
     date_formatted = datetime.datetime.now().strftime('%Y-%m-%d %H.%M.%S.%f')
     log_file = '{}/system_can_{}.log'.format(args.log_dir, date_formatted)
     os.makedirs(os.path.dirname(log_file), exist_ok=True)
-    logging.basicConfig(level=logging.DEBUG, format='%(asctime)s,%(message)s', filename=log_file)
+    logging.basicConfig(level=logging.DEBUG, format='"%(asctime)s",%(message)s', filename=log_file)
 
     print('Masking IDs {}'.format(args.mask))
     if args.device == 'slcan0':


### PR DESCRIPTION
The timestamp has a space, so we should quote this in order to generate CSVs
that can properly be parsed.