### PR TITLE
ELEC-540: Math for State of Charge

### DIFF
--- a/projects/plutus/inc/state_of_charge.h
+++ b/projects/plutus/inc/state_of_charge.h
@@ -53,15 +53,39 @@ typedef struct SocBatterySettings {
 } SocBatterySettings;
 
 // These functions are all pure.
+
+// Returns the rounded product of the first integer by the second fraction.
+int32_t soc_multiply_fraction(int32_t value, SocFraction multiplier);
+
+// Returns the minimum and maximum charges of the passed |batterySettings|.
 int32_t soc_minimum_charge(SocBatterySettings *batterySettings);
 int32_t soc_maximum_charge(SocBatterySettings *batterySettings);
+
+// Returns the minimum and maximum voltages of the passed |batterySettings|.
+// Minimum voltage is just a property access, but is in a function to fit with the other functions.
 int32_t soc_minimum_voltage(SocBatterySettings *batterySettings);
 int32_t soc_maximum_voltage(SocBatterySettings *batterySettings);
-int32_t soc_multiply_fraction(int32_t value, SocFraction multiplier);
+
+// Returns the expected charge for the passed |voltage|.
+// Note the actual charge can vary by some amount.
+// This is a good place to start for initial calibration.
+// The |soc_current_adjusted_voltage| should be the voltage provided.
 int32_t soc_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);
+
+// Returns the minimum or maximum reasonable charge at the given |voltage|.
+// The size of the range can vary, depending on the voltage.
 int32_t soc_minimum_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);
 int32_t soc_maximum_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);
+
+// The voltage across the battery is affected by the current passing through the battery.
+// For the purposes of determining the charge in the battery, this effect should be discounted.
+// This returns the battery's voltage adjusted for this effect.
 int32_t soc_current_adjusted_voltage(int32_t voltage, int32_t current,
                                      SocBatterySettings *batterySettings);
+
+// Returns the current charge in the battery,
+// based on the |old_charge|,
+// as well as the state of the |current| for the |elapsed_time|,
+// and recalibrated if the |voltage| indicates it might be wrong.
 int32_t soc_charge_after_transition(int32_t old_charge, int32_t voltage, int32_t current,
                                     int32_t elapsed_time, SocBatterySettings *batterySettings);

--- a/projects/plutus/inc/state_of_charge.h
+++ b/projects/plutus/inc/state_of_charge.h
@@ -1,0 +1,53 @@
+#pragma once
+#include <stdint.h>
+
+#define SOC_VOLTAGE_STEPS 20
+
+// The following things shouldn't be used outside this module,
+// but are public so they can be properly unit tested.
+
+// Since floating point is not supported,
+// fractions are used for the few situations that cannot be rounded.
+typedef struct SocFraction {
+  int32_t numerator;
+  int32_t denominator;
+} SocFraction;
+
+// Describes the behaviour of the battery.
+// There are units for
+// - Voltage
+// - Current
+// - Time
+// - Charge
+// The scale of these units (milli, micro, etc.) are not important,
+// except the unit of charge must be the product of the unit of current and time.
+typedef struct SocBatterySettings {
+  // |minimum_voltage| and |voltage_step| are used to map voltages to indices in the
+  // |voltage_to_charge| array.
+  int32_t minimum_voltage;
+  int32_t voltage_step;
+
+  // Maps voltages to an expected charge.
+  // It maps in this direction, and not the other, since this direction puts more of the data points
+  // where the curve is more accurate.
+  int32_t voltage_to_charge[SOC_VOLTAGE_STEPS];
+
+  // From those values, other important values can be calculated.
+  // The maximum voltage can be determined.
+  // The maximum and minimum charges can be determined. The coulomb counting can never go outside
+  // these values.
+
+  // How much the voltage can vary from what it should be, based on |voltage_to_charge|.
+  // This can be caused by temperature variance, and the difference between charging and
+  // discharging.
+  int32_t voltage_inaccuracy;
+} SocBatterySettings;
+
+int32_t soc_minimum_charge(SocBatterySettings *batterySettings);
+int32_t soc_maximum_charge(SocBatterySettings *batterySettings);
+int32_t soc_minimum_voltage(SocBatterySettings *batterySettings);
+int32_t soc_maximum_voltage(SocBatterySettings *batterySettings);
+int32_t soc_multiply_fraction(int32_t value, SocFraction multiplier);
+int32_t soc_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);
+int32_t soc_minimum_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);
+int32_t soc_maximum_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);

--- a/projects/plutus/inc/state_of_charge.h
+++ b/projects/plutus/inc/state_of_charge.h
@@ -1,10 +1,10 @@
 #pragma once
 #include <stdint.h>
 
-#define SOC_VOLTAGE_STEPS 20
-
 // The following things shouldn't be used outside this module,
 // but are public so they can be properly unit tested.
+
+#define SOC_VOLTAGE_STEPS 20
 
 // Since floating point is not supported,
 // fractions are used for the few situations that cannot be rounded.
@@ -19,8 +19,10 @@ typedef struct SocFraction {
 // - Current
 // - Time
 // - Charge
+// - Resistance
 // The scale of these units (milli, micro, etc.) are not important,
-// except the unit of charge must be the product of the unit of current and time.
+// except the unit of charge must be the product of the unit of current and time,
+// and the unit of voltage must be the product of current and resistance.
 typedef struct SocBatterySettings {
   // |minimum_voltage| and |voltage_step| are used to map voltages to indices in the
   // |voltage_to_charge| array.
@@ -28,7 +30,7 @@ typedef struct SocBatterySettings {
   int32_t voltage_step;
 
   // Maps voltages to an expected charge.
-  // It maps in this direction, and not the other, since this direction puts more of the data points
+  // It maps in this direction and not the other, since this direction puts more of the data points
   // where the curve is more accurate.
   int32_t voltage_to_charge[SOC_VOLTAGE_STEPS];
 
@@ -41,8 +43,16 @@ typedef struct SocBatterySettings {
   // This can be caused by temperature variance, and the difference between charging and
   // discharging.
   int32_t voltage_inaccuracy;
+
+  // Describes the ratio between the measured current and the effect the current actually has.
+  // Seems some coulombs get lost somehow.
+  SocFraction current_efficiency;
+
+  // The battery has some resistance, so it's rest voltage varies from its apparent voltage.
+  SocFraction internal_resistance;
 } SocBatterySettings;
 
+// These functions are all pure.
 int32_t soc_minimum_charge(SocBatterySettings *batterySettings);
 int32_t soc_maximum_charge(SocBatterySettings *batterySettings);
 int32_t soc_minimum_voltage(SocBatterySettings *batterySettings);
@@ -51,3 +61,7 @@ int32_t soc_multiply_fraction(int32_t value, SocFraction multiplier);
 int32_t soc_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);
 int32_t soc_minimum_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);
 int32_t soc_maximum_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings);
+int32_t soc_current_adjusted_voltage(int32_t voltage, int32_t current,
+                                     SocBatterySettings *batterySettings);
+int32_t soc_charge_after_transition(int32_t old_charge, int32_t voltage, int32_t current,
+                                    int32_t elapsed_time, SocBatterySettings *batterySettings);

--- a/projects/plutus/inc/state_of_charge.h
+++ b/projects/plutus/inc/state_of_charge.h
@@ -1,9 +1,6 @@
 #pragma once
 #include <stdint.h>
 
-// The following things shouldn't be used outside this module,
-// but are public so they can be properly unit tested.
-
 #define SOC_VOLTAGE_STEPS 20
 
 // Since floating point is not supported,

--- a/projects/plutus/src/state_of_charge.c
+++ b/projects/plutus/src/state_of_charge.c
@@ -1,0 +1,66 @@
+#include "state_of_charge.h"
+#include <stdint.h>
+
+int32_t soc_minimum_charge(SocBatterySettings *batterySettings) {
+  return batterySettings->voltage_to_charge[0];
+}
+
+int32_t soc_maximum_charge(SocBatterySettings *batterySettings) {
+  return batterySettings->voltage_to_charge[SOC_VOLTAGE_STEPS - 1];
+}
+
+int32_t soc_minimum_voltage(SocBatterySettings *batterySettings){
+  return batterySettings->minimum_voltage;
+}
+
+int32_t soc_maximum_voltage(SocBatterySettings *batterySettings) {
+  return batterySettings->minimum_voltage + (SOC_VOLTAGE_STEPS - 1) * batterySettings->voltage_step;
+}
+
+// This multiplies the value by the fractional multiplier.
+// This will obviously overflow if the result is too large.
+// It will also overflow for 2,147,483,647 * 2,147,483,647/2,147,483,647, so don't do that.
+// It rounds the result to the nearest integer, and .5s always round away from zero.
+// If this bias becomes a problem, it should be changed to round in some other manner.
+int32_t soc_multiply_fraction(int32_t value, SocFraction multiplier) {
+  int64_t product = (int64_t)value * (int64_t)multiplier.numerator;
+  int64_t round_corrected_product;
+  // != is xor. This always rounds away from zero.
+  if ((product < 0) != (multiplier.denominator < 0)) {
+    round_corrected_product = product - (int64_t)(multiplier.denominator / 2);
+  } else {
+    round_corrected_product = product + (int64_t)(multiplier.denominator / 2);
+  }
+  return (int32_t)(round_corrected_product / multiplier.denominator);
+}
+
+int32_t soc_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings) {
+  if (voltage <= soc_minimum_voltage(batterySettings)) {
+    return soc_minimum_charge(batterySettings);
+  }
+
+  if (voltage >= soc_maximum_voltage(batterySettings)) {
+    return soc_maximum_charge(batterySettings);
+  }
+
+  int32_t voltage_over_minimum = voltage - soc_minimum_voltage(batterySettings);
+
+  int32_t step = voltage_over_minimum / batterySettings->voltage_step;
+  SocFraction interpolation_amount = { voltage_over_minimum % batterySettings->voltage_step, batterySettings->voltage_step };
+
+  int32_t charge_below = batterySettings->voltage_to_charge[step];
+  int32_t charge_above = batterySettings->voltage_to_charge[step + 1];
+
+  int32_t interpolated_amount =
+      soc_multiply_fraction(charge_above - charge_below, interpolation_amount);
+
+  return charge_below + interpolated_amount;
+}
+
+int32_t soc_minimum_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings) {
+  return soc_charge_for_voltage(voltage - batterySettings->voltage_inaccuracy, batterySettings);
+}
+
+int32_t soc_maximum_charge_for_voltage(int32_t voltage, SocBatterySettings *batterySettings) {
+  return soc_charge_for_voltage(voltage + batterySettings->voltage_inaccuracy, batterySettings);
+}

--- a/projects/plutus/test/test_state_of_charge.c
+++ b/projects/plutus/test/test_state_of_charge.c
@@ -1,0 +1,119 @@
+#include <stdint.h>
+#include "log.h"
+#include "state_of_charge.h"
+#include "test_helpers.h"
+#include "unity.h"
+
+SocBatterySettings batterySettings1 = {
+  .minimum_voltage = 1000,  //
+  .voltage_step = 1000,     //
+  .voltage_to_charge = { 100,   150,   250,   400,   600,   900,   1300,  1800,  5100,  12000,
+                         14000, 15000, 15800, 16400, 16900, 17300, 17500, 17650, 17750, 17800 },  //
+  .voltage_inaccuracy = 1000,                                                                     //
+};
+
+SocBatterySettings batterySettings2 = {
+  .minimum_voltage = 10000,  //
+  .voltage_step = 2500,      //
+  .voltage_to_charge = { 1200,   1700,   2700,   4000,   6000,   9000,   13000,
+                         18000,  51000,  120000, 140000, 150000, 158000, 164000,
+                         169000, 173000, 175000, 176500, 177500, 178000 },  //
+  .voltage_inaccuracy = 500,                                                //
+};
+
+void setup_test(void) {}
+
+void teardown_test(void) {}
+
+void test_minimum_charge(void) {
+  TEST_ASSERT_EQUAL(100, soc_minimum_charge(&batterySettings1));
+  TEST_ASSERT_EQUAL(1200, soc_minimum_charge(&batterySettings2));
+}
+
+void test_maximum_charge(void) {
+  TEST_ASSERT_EQUAL(17800, soc_maximum_charge(&batterySettings1));
+  TEST_ASSERT_EQUAL(178000, soc_maximum_charge(&batterySettings2));
+}
+
+void test_minimum_voltage(void) {
+  TEST_ASSERT_EQUAL(1000, soc_minimum_voltage(&batterySettings1));
+  TEST_ASSERT_EQUAL(10000, soc_minimum_voltage(&batterySettings2));
+}
+
+void test_maximum_voltage(void) {
+  TEST_ASSERT_EQUAL(20000, soc_maximum_voltage(&batterySettings1));
+  TEST_ASSERT_EQUAL(57500, soc_maximum_voltage(&batterySettings2));
+}
+
+void test_multiply_fraction(void) {
+  // Without rounding
+  TEST_ASSERT_EQUAL(5, soc_multiply_fraction(10, (SocFraction){ 1, 2 }));
+
+  // Signs
+  TEST_ASSERT_EQUAL(-5, soc_multiply_fraction(-10, (SocFraction){ -1, -2 }));
+  TEST_ASSERT_EQUAL(5, soc_multiply_fraction(-10, (SocFraction){ -1, 2 }));
+  TEST_ASSERT_EQUAL(5, soc_multiply_fraction(-10, (SocFraction){ 1, -2 }));
+  TEST_ASSERT_EQUAL(5, soc_multiply_fraction(10, (SocFraction){ -1, -2 }));
+  TEST_ASSERT_EQUAL(-5, soc_multiply_fraction(10, (SocFraction){ 1, -2 }));
+  TEST_ASSERT_EQUAL(-5, soc_multiply_fraction(10, (SocFraction){ -1, 2 }));
+  TEST_ASSERT_EQUAL(-5, soc_multiply_fraction(-10, (SocFraction){ 1, 2 }));
+
+  // Large numbers
+  TEST_ASSERT_EQUAL(1073741823, soc_multiply_fraction(2147483646, (SocFraction){ 8, 16 }));
+
+  // Rounding and sign
+  TEST_ASSERT_EQUAL(1, soc_multiply_fraction(4, (SocFraction){ 1, 3 }));
+  TEST_ASSERT_EQUAL(-1, soc_multiply_fraction(-4, (SocFraction){ 1, 3 }));
+  TEST_ASSERT_EQUAL(2, soc_multiply_fraction(5, (SocFraction){ 1, 3 }));
+  TEST_ASSERT_EQUAL(-2, soc_multiply_fraction(-5, (SocFraction){ 1, 3 }));
+  TEST_ASSERT_EQUAL(2, soc_multiply_fraction(6, (SocFraction){ 1, 4 }));
+  TEST_ASSERT_EQUAL(-2, soc_multiply_fraction(-6, (SocFraction){ 1, 4 }));
+}
+
+void test_charge_for_voltage(void) {
+  // Voltages below the minimum
+  TEST_ASSERT_EQUAL(100, soc_charge_for_voltage(0, &batterySettings1));
+  TEST_ASSERT_EQUAL(1200, soc_charge_for_voltage(0, &batterySettings2));
+
+  // Voltages above the maximum
+  TEST_ASSERT_EQUAL(17800, soc_charge_for_voltage(21000, &batterySettings1));
+  TEST_ASSERT_EQUAL(178000, soc_charge_for_voltage(60000, &batterySettings2));
+
+  // Voltages at the minimum
+  TEST_ASSERT_EQUAL(100, soc_charge_for_voltage(1000, &batterySettings1));
+  TEST_ASSERT_EQUAL(1200, soc_charge_for_voltage(10000, &batterySettings2));
+
+  // Voltages at the maximum
+  TEST_ASSERT_EQUAL(17800, soc_charge_for_voltage(20000, &batterySettings1));
+  TEST_ASSERT_EQUAL(178000, soc_charge_for_voltage(57500, &batterySettings2));
+
+  // Voltages at a specific step
+  TEST_ASSERT_EQUAL(12000, soc_charge_for_voltage(10000, &batterySettings1));
+  TEST_ASSERT_EQUAL(6000, soc_charge_for_voltage(20000, &batterySettings2));
+
+  // Voltages in the middle of the first two steps
+  TEST_ASSERT_EQUAL(125, soc_charge_for_voltage(1500, &batterySettings1));
+  TEST_ASSERT_EQUAL(1450, soc_charge_for_voltage(11250, &batterySettings2));
+
+  // Voltages in the middle of the last two steps
+  TEST_ASSERT_EQUAL(17775, soc_charge_for_voltage(19500, &batterySettings1));
+  TEST_ASSERT_EQUAL(177750, soc_charge_for_voltage(56250, &batterySettings2));
+
+  // Voltages with some offset
+  TEST_ASSERT_EQUAL(112, soc_charge_for_voltage(1234, &batterySettings1));
+  TEST_ASSERT_EQUAL(1669, soc_charge_for_voltage(12345, &batterySettings2));
+}
+
+void test_minimum_charge_for_voltage(void) {
+  TEST_ASSERT_EQUAL(17700, soc_minimum_charge_for_voltage(19500, &batterySettings1));
+  TEST_ASSERT_EQUAL(177750, soc_minimum_charge_for_voltage(56750, &batterySettings2));
+  TEST_ASSERT_EQUAL(112, soc_minimum_charge_for_voltage(2234, &batterySettings1));
+  TEST_ASSERT_EQUAL(1669, soc_minimum_charge_for_voltage(12845, &batterySettings2));
+}
+
+void test_maximum_charge_for_voltage(void) {
+  TEST_ASSERT_EQUAL(200, soc_maximum_charge_for_voltage(1500, &batterySettings1));
+  TEST_ASSERT_EQUAL(1450, soc_maximum_charge_for_voltage(10750, &batterySettings2));
+  TEST_ASSERT_EQUAL(112, soc_maximum_charge_for_voltage(234, &batterySettings1));
+  TEST_ASSERT_EQUAL(1669, soc_maximum_charge_for_voltage(11845, &batterySettings2));
+}

--- a/projects/plutus/test/test_state_of_charge.c
+++ b/projects/plutus/test/test_state_of_charge.c
@@ -10,6 +10,8 @@ SocBatterySettings batterySettings1 = {
   .voltage_to_charge = { 100,   150,   250,   400,   600,   900,   1300,  1800,  5100,  12000,
                          14000, 15000, 15800, 16400, 16900, 17300, 17500, 17650, 17750, 17800 },  //
   .voltage_inaccuracy = 1000,                                                                     //
+  .current_efficiency = { 63, 64 },
+  .internal_resistance = { 1, 4 }
 };
 
 SocBatterySettings batterySettings2 = {
@@ -19,6 +21,8 @@ SocBatterySettings batterySettings2 = {
                          18000,  51000,  120000, 140000, 150000, 158000, 164000,
                          169000, 173000, 175000, 176500, 177500, 178000 },  //
   .voltage_inaccuracy = 500,                                                //
+  .current_efficiency = { 3, 4 },
+  .internal_resistance = { 1, 64 }
 };
 
 void setup_test(void) {}
@@ -116,4 +120,24 @@ void test_maximum_charge_for_voltage(void) {
   TEST_ASSERT_EQUAL(1450, soc_maximum_charge_for_voltage(10750, &batterySettings2));
   TEST_ASSERT_EQUAL(112, soc_maximum_charge_for_voltage(234, &batterySettings1));
   TEST_ASSERT_EQUAL(1669, soc_maximum_charge_for_voltage(11845, &batterySettings2));
+}
+
+void test_current_adjusted_voltage(void) {
+  TEST_ASSERT_EQUAL(10, soc_current_adjusted_voltage(13, 12, &batterySettings1));
+  TEST_ASSERT_EQUAL(121, soc_current_adjusted_voltage(123, 128, &batterySettings2));
+}
+
+void test_charge_after_transition(void) {
+  // Regular change
+  TEST_ASSERT_EQUAL(150, soc_charge_after_transition(126, 2003, 12, 2, &batterySettings1));
+  TEST_ASSERT_EQUAL(1700, soc_charge_after_transition(1316, 12502, 128, 4, &batterySettings2));
+  // Reverse change
+  TEST_ASSERT_EQUAL(150, soc_charge_after_transition(174, 1997, -12, 2, &batterySettings1));
+  TEST_ASSERT_EQUAL(1700, soc_charge_after_transition(2084, 12498, -128, 4, &batterySettings2));
+  // Calibrating down
+  TEST_ASSERT_EQUAL(150, soc_charge_after_transition(10000, 1003, 12, 2, &batterySettings1));
+  TEST_ASSERT_EQUAL(1700, soc_charge_after_transition(100000, 12002, 128, 4, &batterySettings2));
+  // Calibrating up
+  TEST_ASSERT_EQUAL(150, soc_charge_after_transition(-10000, 3003, 12, 2, &batterySettings1));
+  TEST_ASSERT_EQUAL(1700, soc_charge_after_transition(-100000, 13002, 128, 4, &batterySettings2));
 }


### PR DESCRIPTION
This PR contains all the math for state of charge. Specifically, it contains a way to calculate the charge of some cell, based on the previous charge, as well as the current, voltage, and amount of time passed.

It doesn't contain anything to actually hook it up to the car (e.g. persistence, actually sending the messages to where ever it needs to go, calibration), since it sounds like we don't have the data we need to calibrate it right now.