### PR TITLE
ELEC-583: Fix AFE discharge indices

### DIFF
--- a/projects/plutus/inc/ltc_afe.h
+++ b/projects/plutus/inc/ltc_afe.h
@@ -92,6 +92,7 @@ typedef struct LtcAfeStorage {
   // Discharge enabled - device-relative
   uint16_t discharge_bitset[PLUTUS_CFG_AFE_DEVICES_IN_CHAIN];
   // Lookup table for mapping cell -> actual device-relative AFE cell
+  // discharge_cell_lookup[logical cell index] = physical cell index;
   // TODO(ELEC-447): Handle unused cell inputs during balancing
   uint16_t discharge_cell_lookup[LTC_AFE_MAX_TOTAL_CELLS];
 

--- a/projects/plutus/src/ltc_afe_impl.c
+++ b/projects/plutus/src/ltc_afe_impl.c
@@ -149,7 +149,6 @@ static void prv_calc_offsets(LtcAfeStorage *afe) {
   // Similarly, we do the opposite mapping for discharge.
   size_t cell_index = 0;
   size_t aux_index = 0;
-  size_t discharge_index = 0;
   for (size_t device = 0; device < PLUTUS_CFG_AFE_DEVICES_IN_CHAIN; device++) {
     for (size_t device_cell = 0; device_cell < LTC_AFE_MAX_CELLS_PER_DEVICE; device_cell++) {
       size_t cell = device * LTC_AFE_MAX_CELLS_PER_DEVICE + device_cell;
@@ -280,11 +279,11 @@ StatusCode ltc_afe_impl_toggle_cell_discharge(LtcAfeStorage *afe, uint16_t cell,
   }
 
   uint16_t actual_cell = afe->discharge_cell_lookup[cell];
-  uint16_t device = actual_cell % LTC_AFE_MAX_CELLS_PER_DEVICE;
-  uint16_t device_cell = actual_cell / LTC_AFE_MAX_CELLS_PER_DEVICE;
+  uint16_t device_cell = actual_cell % LTC_AFE_MAX_CELLS_PER_DEVICE;
+  uint16_t device = actual_cell / LTC_AFE_MAX_CELLS_PER_DEVICE;
 
   if (discharge) {
-    afe->discharge_bitset[device] |= 1 << device_cell;
+    afe->discharge_bitset[device] |= (1 << device_cell);
   } else {
     afe->discharge_bitset[device] &= ~(1 << device_cell);
   }


### PR DESCRIPTION
I was looking through the AFE driver and noticed that the device and cell values used for the reverse discharge mapping lookup is reversed. As such, you potentially get reads past the buffer, which will probably result in setting the wrong index.

This fixes this problem, and clarifies how the mapping works.