### PR TITLE
ELEC-588: Remove reallyclean target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,18 +12,18 @@
 #
 # Usage:
 #   make [all] [PL] [PR] - Builds the target project and its dependencies
-#   make clean [PL] [PR] - Removes the project's build output and associated linker and object files
-#   make remake [PL] [PR] - Cleans and rebuilds the target project (does not force-rebuild dependencies)
-#   make reallyclean - Completely deletes all build output
-#   make new [PR|LI] - Creates folder structure for new project or library
-#   make lint - Lints all non-vendor code
-#   make test [PL] [PR|LI] [TE] - Builds and runs the specified unit test, assuming all tests if TE is not defined
+#   make clean - Completely deletes all build output
 #   make format - Formats all non-vendor code
 #   make gdb [PL] [PR|LI] [TE] - Builds and runs the specified unit test and connects an instance of GDB
+#   make lint - Lints all non-vendor code
+#   make new [PR|LI] - Creates folder structure for new project or library
+#   make remake [PL] [PR] - Cleans and rebuilds the target project (does not force-rebuild dependencies)
+#   make test [PL] [PR|LI] [TE] - Builds and runs the specified unit test, assuming all tests if TE is not defined
 #   make update_codegen - Update the codegen-tooling release
+#
 # Platform specific:
-#   make program [PL=stm32f0xx] [PR] [PB] - Programs and runs the project through OpenOCD
 #   make gdb [PL=stm32f0xx] [PL] [PR] [PB]
+#   make program [PL=stm32f0xx] [PR] [PB] - Programs and runs the project through OpenOCD
 #   make <build | test | remake | all> [PL=x86] [CM=clang [CO]]
 #
 ###################################################################################################
@@ -114,9 +114,8 @@ ROOT := $(shell pwd)
 
 # MAKE PROJECT
 
-.PHONY: all lint pylint format build build_all
-
 # Actually calls the make
+.PHONY: all
 all: build lint pylint
 
 # Includes platform-specific configurations
@@ -135,12 +134,14 @@ FIND := find $(PROJ_DIR) $(LIB_DIR) \
 				-iname "*.[ch]" -print
 
 # Lints libraries and projects, excludes IGNORE_CLEANUP_LIBS
+.PHONY: lint
 lint:
 	@echo "Linting *.[ch] in $(PROJ_DIR), $(LIB_DIR)"
 	@echo "Excluding libraries: $(IGNORE_CLEANUP_LIBS)"
 	@$(FIND) | xargs -r python2 lint.py
 
 # Disable import error
+.PHONY: pylint
 pylint:
 	@echo "Linting *.py in $(MAKE_DIR), $(PLATFORMS_DIR), $(PROJ_DIR), $(LIB_DIR)"
 	@echo "Excluding libraries: $(IGNORE_CLEANUP_LIBS)"
@@ -148,16 +149,19 @@ pylint:
 	@$(FIND:"*.[ch]"="*.py") | xargs -r pylint --disable=F0401 --disable=duplicate-code
 
 # Formats libraries and projects, excludes IGNORE_CLEANUP_LIBS
+.PHONY: format
 format:
 	@echo "Formatting *.[ch] in $(PROJ_DIR), $(LIB_DIR)"
 	@echo "Excluding libraries: $(IGNORE_CLEANUP_LIBS)"
 	@$(FIND) | xargs -r clang-format -i -style=file
 
 # Tests that all files have been run through the format target mainly for CI usage
+.PHONY: test_format
 test_format: format
 	@! git diff --name-only --diff-filter=ACMRT | xargs -n1 clang-format -style=file -output-replacements-xml | grep '<replacements' > /dev/null; if [ $$? -ne 0 ] ; then git --no-pager diff && exit 1 ; fi
 
 # Builds the project or library
+.PHONY: build
 ifneq (,$(PROJECT)$(TEST))
 build: $(TARGET_BINARY)
 else
@@ -165,6 +169,7 @@ build: $(STATIC_LIB_DIR)/lib$(LIBRARY).a
 endif
 
 # Assumes that all libraries are used and will be built along with the projects
+.PHONY: build_all
 build_all: $(VALID_PROJECTS:%=$(BIN_DIR)/%$(PLATFORM_EXT))
 
 $(DIRS):
@@ -177,22 +182,19 @@ $(BIN_DIR)/%.bin: $(BIN_DIR)/%$(PLATFORM_EXT)
 
 # EXTRA
 
-# clean and remake rules, use reallyclean to clean everything
-
-.PHONY: clean reallyclean remake new socketcan update_codegen .FORCE
-
+# Creates folder structure for a new project or library
+.PHONY: new
 new:
 	@python3 $(MAKE_DIR)/new_target.py $(NEW_TYPE) $(PROJECT)$(LIBRARY)
 
+.PHONY: clean
 clean:
-	@find ./ -name '*~' | xargs rm -f
-	@rm -rf $(BIN_DIR)
-
-reallyclean: clean
 	@rm -rf $(BUILD_DIR)
 
+.PHONY: remake
 remake: clean all
 
+.PHONY: socketcan
 socketcan:
 	@sudo modprobe can
 	@sudo modprobe can_raw
@@ -201,5 +203,9 @@ socketcan:
 	@sudo ip link set up vcan0 || true
 	@ip link show vcan0
 
+.PHONY: update_codegen
 update_codegen:
 	@python make/git_fetch.py -folder=libraries/codegen-tooling -user=uw-midsun -repo=codegen-tooling -tag=latest -file=codegen-tooling-out.zip
+
+# Dummy force target for pre-build steps
+.PHONY: .FORCE

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ make gdb TEST=can LIBRARY=ms-common
 make new PROJECT=new_project_name
 
 # Nukes the build directory - use when things aren't working
-make reallyclean
+make clean
 
 # Linting and formatting - used to help enforce our coding style
 make format
@@ -60,7 +60,7 @@ If you have Clang/LLVM/Bear installed and want to debug on x86 more easily/more 
 To create a compile commands database, run
 
 ```bash
-make reallyclean
+make clean
 bear make build_all PLATFORM=x86
 ```
 
@@ -75,7 +75,7 @@ clang-tidy $PATH_TO_C_FILE -checks=*
 To build in debug with memory and address sanitation and extended stack traces on faults, run
 
 ```bash
-make reallyclean
+make clean
 make build_all PLATFORM=x86 COMPILER=clang COPTIONS=asan
 ```
 
@@ -86,7 +86,7 @@ If you run any of the resulting binaries and a memory error of any kind occurs t
 To build in debug with thread sanitation run
 
 ```bash
-make reallyclean
+make clean
 make build_all PLATFORM=x86 COMPILER=clang COPTIONS=tsan
 ```
 

--- a/make/filter.mk
+++ b/make/filter.mk
@@ -3,13 +3,13 @@ VALID_PLATFORMS := $(patsubst $(PLATFORMS_DIR)/%/platform.mk,%,$(wildcard $(PLAT
 VALID_LIBRARIES := $(patsubst $(LIB_DIR)/%/rules.mk,%,$(wildcard $(LIB_DIR)/*/rules.mk))
 
 # Rules:
-# - For any universal operations (reallyclean, lint), do not expect args
+# - For any universal operations (clean, lint), do not expect args
 # - For build/test all, just check for a valid PLATFORM.
 # - If new project, just make sure one of PROJECT or LIBRARY is defined
 # - For test, gdb, and program, check to see if PLATFORM and {PROJECT or {LIBRARY and TEST}} are valid
 # - For build, check if PLATFORM and {PROJECT or LIBRARY} are valid
 
-ifneq (,$(filter reallyclean lint pylint format build_all test_all test_format socketcan update_codegen,$(MAKECMDGOALS)))
+ifneq (,$(filter clean lint pylint format build_all test_all test_format socketcan update_codegen,$(MAKECMDGOALS)))
   # Universal operation: do nothing - args are not used or only PLATFORM is checked
 else ifneq (,$(filter new,$(MAKECMDGOALS)))
   # New project: just make sure PROJECT or LIBRARY is defined


### PR DESCRIPTION
Remove the distinction between the `clean` and `reallyclean` targets.

This creates a lot of confusion, and there are very few cases where the
intended behaviour is to only clean a specific project. Moreover, in the
interests of keeping things consistent with typical conventions, this
renames the `reallyclean` target to `clean`.