### PR TITLE
ELEC-533: Changed init to retry and assert success

### DIFF
--- a/libraries/x86/src/x86_socket.c
+++ b/libraries/x86/src/x86_socket.c
@@ -150,6 +150,7 @@ StatusCode x86_socket_write(int client_fd, const char *tx_data, size_t tx_len) {
   ssize_t write_len = write(client_fd, tx_data, tx_len);
 
   if (write_len < 0) {
+    LOG_CRITICAL("x86_socket_write failed: %s\n", strerror(errno));
     return status_code(STATUS_CODE_INTERNAL_ERROR);
   }
 
@@ -159,11 +160,26 @@ StatusCode x86_socket_write(int client_fd, const char *tx_data, size_t tx_len) {
 int test_x86_socket_client_init(const char *module_name) {
   // Set up connection to abstract domain socket @[pid]/[prog]/test_x86_socket
   int client_fd = socket(AF_UNIX, SOCK_SEQPACKET, 0);
+
+  if (client_fd < 0) {
+    LOG_CRITICAL("Failed to create socket: %s\n", strerror(errno));
+  }
+
   struct sockaddr_un addr = { .sun_family = AF_UNIX };
   snprintf(addr.sun_path + 1, sizeof(addr.sun_path) - 1, "%d/%s/%s", getpid(),
            program_invocation_short_name, module_name);
-  connect(client_fd, (struct sockaddr_un *)&addr,
-          offsetof(struct sockaddr_un, sun_path) + 1 + strlen(addr.sun_path + 1));
+
+  int result = X86_SOCKET_INVALID_FD;
+
+  for (int i = 0; i < 5 && result == X86_SOCKET_INVALID_FD; i++) {
+    result = connect(client_fd, (struct sockaddr_un *)&addr,
+                     offsetof(struct sockaddr_un, sun_path) + 1 + strlen(addr.sun_path + 1));
+
+    if (result == X86_SOCKET_INVALID_FD) {
+      LOG_CRITICAL("Failed to connect to socket: %s\n", strerror(errno));
+    }
+    sleep(1);
+  }
 
   return client_fd;
 }

--- a/libraries/x86/src/x86_socket.c
+++ b/libraries/x86/src/x86_socket.c
@@ -171,13 +171,15 @@ int test_x86_socket_client_init(const char *module_name) {
 
   int result = X86_SOCKET_INVALID_FD;
 
-  for (int i = 0; i < 5 && result == X86_SOCKET_INVALID_FD; i++) {
+  for (int i = 0; i < 5; i++) {
     result = connect(client_fd, (struct sockaddr_un *)&addr,
                      offsetof(struct sockaddr_un, sun_path) + 1 + strlen(addr.sun_path + 1));
 
-    if (result == X86_SOCKET_INVALID_FD) {
-      LOG_CRITICAL("Failed to connect to socket: %s\n", strerror(errno));
+    if (result != X86_SOCKET_INVALID_FD) {
+      break;
     }
+
+    LOG_CRITICAL("Failed to connect to socket: %s\n", strerror(errno));
     sleep(1);
   }
 

--- a/libraries/x86/test/test_x86_cmd.c
+++ b/libraries/x86/test/test_x86_cmd.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include "log.h"
 #include "unity.h"
+#include "test_helpers.h"
 #include "x86_cmd.h"
 
 static char s_cmd[30];

--- a/libraries/x86/test/test_x86_cmd.c
+++ b/libraries/x86/test/test_x86_cmd.c
@@ -38,7 +38,7 @@ void test_x86_cmd_client(void) {
 
   const char *cmd = "test a b c d";
   LOG_DEBUG("Sending command: \"%s\"\n", cmd);
-  x86_socket_write(client_fd, cmd, strlen(cmd));
+  TEST_ASSERT_TRUE(status_ok(x86_socket_write(client_fd, cmd, strlen(cmd))));
 
   while (!received) {
   }

--- a/libraries/x86/test/test_x86_cmd.c
+++ b/libraries/x86/test/test_x86_cmd.c
@@ -1,8 +1,8 @@
 #include <stdbool.h>
 #include <string.h>
 #include "log.h"
-#include "unity.h"
 #include "test_helpers.h"
+#include "unity.h"
 #include "x86_cmd.h"
 
 static char s_cmd[30];

--- a/libraries/x86/test/test_x86_cmd.c
+++ b/libraries/x86/test/test_x86_cmd.c
@@ -38,7 +38,7 @@ void test_x86_cmd_client(void) {
 
   const char *cmd = "test a b c d";
   LOG_DEBUG("Sending command: \"%s\"\n", cmd);
-  TEST_ASSERT_TRUE(status_ok(x86_socket_write(client_fd, cmd, strlen(cmd))));
+  TEST_ASSERT_OK(x86_socket_write(client_fd, cmd, strlen(cmd)));
 
   while (!received) {
   }


### PR DESCRIPTION
I was messing around with this and I think I fixed it.

I think the issue was that on slow machines the `connect()` happens before the socket is fully initialized (judging by the log output and the solution).

As a fix, when the `connect()` fails, we retry a couple of times. As well, we assert that the `x86_socket_write` actually succeeds. So if the first fix does not work, at least the test will not hang.