### PR TITLE
ELEC-71: Turn on GPS module via message

### DIFF
--- a/projects/telemetry/inc/gps.h
+++ b/projects/telemetry/inc/gps.h
@@ -31,10 +31,6 @@
 typedef struct {
   UartPort port;
   UartSettings *uart_settings;  // The uart settings to be used
-  GpioAddress *pin_rx;          // Pin addresses
-  GpioAddress *pin_tx;
-  GpioAddress *pin_power;
-  GpioAddress *pin_on_off;
   UartStorage uart_storage;
 } GpsSettings;
 

--- a/projects/telemetry/inc/gps.h
+++ b/projects/telemetry/inc/gps.h
@@ -16,6 +16,9 @@
 // A GGA message will be around a hundred characters.
 #define GPS_MAX_NMEA_LENGTH 128
 
+// NMEA sentence to turn GPS module on
+#define GPS_FULL_POWER "PLSC,200,1*0F\r\n" 
+
 // NMEA sentences to transmit to the GPS module to turn off unneeded messages
 #define GPS_GLL_OFF "$PSRF103,01,00,00,01*27\r\n"  // GLL: Geographic Position - Latitude/Longitude
 #define GPS_GSA_OFF "$PSRF103,02,00,00,01*26\r\n"  // GSA: GPS DOP and Active Satellites

--- a/projects/telemetry/src/main.c
+++ b/projects/telemetry/src/main.c
@@ -3,16 +3,13 @@
 #include <stdint.h>
 #include "can_hw.h"
 #include "can_uart.h"
-#include "delay.h"
 #include "event_queue.h"
-#include "gpio.h"
 #include "gps.h"
 #include "interrupt.h"
 #include "log.h"
 #include "nmea.h"
 #include "soft_timer.h"
 #include "uart.h"
-#include "wait.h"
 
 UartSettings telemetry_gps_uart_settings = {
   .baudrate = 9600,

--- a/projects/telemetry/src/main.c
+++ b/projects/telemetry/src/main.c
@@ -14,29 +14,15 @@
 #include "uart.h"
 #include "wait.h"
 
-GpioSettings telemetry_settings_gpio_general = {
-  .direction = GPIO_DIR_OUT,  // The pin needs to output.
-  .state = GPIO_STATE_LOW,    // Start in the "off" state.
-  .alt_function = GPIO_ALTFN_1,
-};
-
 UartSettings telemetry_gps_uart_settings = {
   .baudrate = 9600,
-  .tx = { .port = GPIO_PORT_A, .pin = 2 },
-  .rx = { .port = GPIO_PORT_A, .pin = 3 },
-  .alt_fn = GPIO_ALTFN_1,
+  .tx = { .port = GPIO_PORT_B, .pin = 10 },
+  .rx = { .port = GPIO_PORT_B, .pin = 11 },
+  .alt_fn = GPIO_ALTFN_4,
 };
 
-// The pin numbers to use for providing power and turning the GPS on and off
-GpioAddress telemetry_gps_pins[] = {
-  { .port = GPIO_PORT_B, .pin = 3 },  // Pin GPS power
-  { .port = GPIO_PORT_B, .pin = 4 },  // Pin GPS on_off
-};
-
-GpsSettings telemetry_gps_settings = { .pin_power = &telemetry_gps_pins[0],
-                                       .pin_on_off = &telemetry_gps_pins[1],
-                                       .uart_settings = &telemetry_gps_uart_settings,
-                                       .port = UART_PORT_2 };
+GpsSettings telemetry_gps_settings = { .uart_settings = &telemetry_gps_uart_settings,
+                                       .port = UART_PORT_3 };
 
 GpsStorage telemetry_gps_storage = { 0 };
 

--- a/projects/telemetry/test/test_gps.c
+++ b/projects/telemetry/test/test_gps.c
@@ -15,20 +15,12 @@
 
 UartSettings telemetry_gps_uart_settings = {
   .baudrate = 9600,
-  .tx = { .port = GPIO_PORT_A, .pin = 2 },
-  .rx = { .port = GPIO_PORT_A, .pin = 3 },
-  .alt_fn = GPIO_ALTFN_NONE,
+  .tx = { .port = GPIO_PORT_B, .pin = 10 },
+  .rx = { .port = GPIO_PORT_B, .pin = 11 },
+  .alt_fn = GPIO_ALTFN_4,
 };
 
-// The pin numbers to use for providing power and turning the GPS on and off
-GpioAddress telemetry_gps_pins[] = {
-  { .port = GPIO_PORT_B, .pin = 3 },  // Pin GPS power
-  { .port = GPIO_PORT_B, .pin = 4 },  // Pin GPS on_off
-};
-
-GpsSettings telemetry_gps_settings = { .pin_power = &telemetry_gps_pins[0],
-                                       .pin_on_off = &telemetry_gps_pins[1],
-                                       .uart_settings = &telemetry_gps_uart_settings,
+GpsSettings telemetry_gps_settings = { .uart_settings = &telemetry_gps_uart_settings,
                                        .port = UART_PORT_2 };
 
 GpsStorage telemetry_gps_storage = { 0 };


### PR DESCRIPTION
Right now, the GPS board is designed so that a constant voltage is applied to the VCC and the ON/OFF pin. The original driver pulses the ON/OFF pin to turn it on. Thus, the GPS driver must be changed to comply with this design.

Main Changes  
- Removed anything responsible for controlling the VCC or ON/OFF pins
- Driver now sends an NMEA message to turn on the GPS module instead of pulsing the ON/OFF pin