### PR TITLE
ELEC-622: Firmware Tutorial On-board Module 1

### DIFF
--- a/projects/fw_tutorial/README.md
+++ b/projects/fw_tutorial/README.md
@@ -1,0 +1,31 @@
+# Firmware Tutorial
+
+This is the Midnight Sun firmware tutorial module which introduces fundamental hardware
+and firmware concepts from reading schematics to writing functional code following our 
+standards. This module requires the use of the Midnight Sun Tutorial Board and is a series
+of 2 modules where once completed, will enable one to become a contributing member to our
+firmware team! 
+
+## Module 1: Digital and Analog I/O
+
+The first module introduces to concept of writing firmware, more specifically, Midnight
+Sun approved firmware! The module goes over key concepts such as file layout/structure,
+reading schematics, logging/debugging and writing unit tests. By the end of this module, 
+one should be familiar with interacting with hardware peripherals and reading in both 
+analog and digital signals. 
+
+Problem Statement: 
+- Control LEDs with corresponding buttons through a microcontroller
+- Adjust brightness of LEDs using potentiometer while logging the analog data
+
+## Module 2: CAN
+
+The second module goes over our most commonly used protocol, CAN. This module takes one
+through the fundamentals of CAN messages, creating new CAN messages, utilizing CAN to 
+send messages across boards and debugging CAN messages via a Peak CAN. By the end of this
+module, one should be familiar with our codegen repository and have to ability to 
+initiate effective board-to-board communication through the use of CAN messages.
+
+Problem Statement:
+- Define and generate custom CAN message through our codegen repository
+- Control LEDs with through CAN messages from one board to another

--- a/projects/fw_tutorial/example/button.c
+++ b/projects/fw_tutorial/example/button.c
@@ -38,7 +38,7 @@ StatusCode button_init(const ButtonSettings *settings, ButtonStorage *storage) {
     // Initialize the LED GPIO
     status_ok_or_return(gpio_init_pin(&settings->led_addresses[i], &led_settings));
 
-    // Initializae the button GPIO and register its interrupt
+    // Initialize the button GPIO and register its interrupt
     status_ok_or_return(gpio_init_pin(&settings->button_addresses[i], &gpio_settings));
     status_ok_or_return(
         gpio_it_register_interrupt(&settings->button_addresses[i], &settings->interrupt_settings,

--- a/projects/fw_tutorial/example/button.c
+++ b/projects/fw_tutorial/example/button.c
@@ -1,0 +1,50 @@
+#include "button.h"
+#include <stddef.h>
+#include <stdio.h>
+
+static void prv_button_callback(const GpioAddress *address, void *context) {
+  ButtonStorage *storage = (ButtonStorage *)context;
+
+  // Increment counter
+  storage->count++;
+
+  // Toggle the appropriate LED
+  gpio_toggle_state(&storage->led_address);
+}
+
+StatusCode button_init(const ButtonSettings *settings, ButtonStorage *storage) {
+  // Argument checking
+  if (settings == NULL || storage == NULL) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+
+  // GPIO settings for push-button
+  GpioSettings gpio_settings = { .direction = GPIO_DIR_IN,
+                                 .state = GPIO_STATE_LOW,
+                                 .resistor = GPIO_RES_NONE,
+                                 .alt_function = GPIO_ALTFN_NONE };
+
+  // GPIO settings for LED
+  GpioSettings led_settings = { .direction = GPIO_DIR_OUT,
+                                .state = GPIO_STATE_LOW,
+                                .resistor = GPIO_RES_NONE,
+                                .alt_function = GPIO_ALTFN_NONE };
+
+  // Initialize all the buttons
+  for (uint8_t i = 0; i < NUM_BUTTON_COLOURS; i++) {
+    // Store the LED address
+    storage[i].led_address = settings->led_addresses[i];
+
+    // Initialize the LED GPIO
+    status_ok_or_return(gpio_init_pin(&settings->led_addresses[i], &led_settings));
+
+    // Initializae the button GPIO and register its interrupt
+    status_ok_or_return(gpio_init_pin(&settings->button_addresses[i], &gpio_settings));
+    status_ok_or_return(
+        gpio_it_register_interrupt(&settings->button_addresses[i], &settings->interrupt_settings,
+                                   settings->interrupt_edge, prv_button_callback, &storage[i]));
+  }
+
+  // Everything has been initialized properly
+  return STATUS_CODE_OK;
+}

--- a/projects/fw_tutorial/example/config.c
+++ b/projects/fw_tutorial/example/config.c
@@ -1,0 +1,27 @@
+#include "config.h"
+
+// Button settings
+static ButtonSettings button_settings = {
+  .button_addresses = { [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 0 },     // Green button pin
+                        [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_A, 7 } },  // Yellow button pin
+  .led_addresses = { [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 3 },        // Green button LED pin
+                     [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_B, 4 } },     // Yellow button LED pin
+  // No other interrupts expected, leave priority as normal
+  .interrupt_settings = { INTERRUPT_TYPE_INTERRUPT, INTERRUPT_PRIORITY_NORMAL },
+  .interrupt_edge = INTERRUPT_EDGE_RISING  // Trigger on the rising edge
+};
+
+// Potentiometer settings
+static PotentiometerSettings potentiometer_settings = {
+  // TODO(ELEC-624): Change this once hardware revision updates
+  .adc_address = { GPIO_PORT_A, 0 },             // Potentiometer pin
+  .update_period_s = CONFIG_ADC_UPDATE_PERIOD_S  // Update period
+};
+
+ButtonSettings *config_load_buttons(void) {
+  return &button_settings;
+}
+
+PotentiometerSettings *config_load_potentiometer(void) {
+  return &potentiometer_settings;
+}

--- a/projects/fw_tutorial/inc/button.h
+++ b/projects/fw_tutorial/inc/button.h
@@ -1,0 +1,34 @@
+#pragma once
+// Push button module for LED control written for the Tutorial board
+// This module is used as an introduction to Midnight Sun style firmware.
+// It is organized in such a way as to expose the user to basic fundamentals
+// and principals we follow when writing drivers and modules
+// Requires interrupts to be initialized
+#include "gpio.h"
+#include "gpio_it.h"
+
+// Type of Button
+typedef enum {
+  BUTTON_COLOUR_YELLOW = 0,
+  BUTTON_COLOUR_GREEN,
+  NUM_BUTTON_COLOURS,
+} ButtonColour;
+
+// Button settings structure
+typedef struct ButtonSettings {
+  GpioAddress button_addresses[NUM_BUTTON_COLOURS]; // Array of GPIO addresses for each push button
+  GpioAddress led_addresses[NUM_BUTTON_COLOURS];  // Array of GPIO addresses for each LED
+  GpioSettings gpio_settings; // GPIO settings for the push-button (input)
+  GpioSettings led_settings; // GPIO settings for LED (output)
+  InterruptSettings interrupt_settings; // Interrupt settings for push-buttons
+  InterruptEdge interrupt_edge; // Interrupt trigger edge for push-buttons
+} ButtonSettings;
+
+// Button storage structure
+typedef struct ButtonStorage {
+  GpioAddress led_address; // GPIO address for the associated LED
+  volatile uint32_t count; // Count of button presses
+} ButtonStorage;
+
+// Initializes the button GPIOs and corresponding LED outputs
+StatusCode button_init(const ButtonSettings *settings, ButtonStorage *storage);

--- a/projects/fw_tutorial/inc/button.h
+++ b/projects/fw_tutorial/inc/button.h
@@ -16,18 +16,18 @@ typedef enum {
 
 // Button settings structure
 typedef struct ButtonSettings {
-  GpioAddress button_addresses[NUM_BUTTON_COLOURS]; // Array of GPIO addresses for each push button
-  GpioAddress led_addresses[NUM_BUTTON_COLOURS];  // Array of GPIO addresses for each LED
-  GpioSettings gpio_settings; // GPIO settings for the push-button (input)
-  GpioSettings led_settings; // GPIO settings for LED (output)
-  InterruptSettings interrupt_settings; // Interrupt settings for push-buttons
-  InterruptEdge interrupt_edge; // Interrupt trigger edge for push-buttons
+  GpioAddress button_addresses[NUM_BUTTON_COLOURS];  // Array of GPIO addresses for each push button
+  GpioAddress led_addresses[NUM_BUTTON_COLOURS];     // Array of GPIO addresses for each LED
+  GpioSettings gpio_settings;                        // GPIO settings for the push-button (input)
+  GpioSettings led_settings;                         // GPIO settings for LED (output)
+  InterruptSettings interrupt_settings;              // Interrupt settings for push-buttons
+  InterruptEdge interrupt_edge;                      // Interrupt trigger edge for push-buttons
 } ButtonSettings;
 
 // Button storage structure
 typedef struct ButtonStorage {
-  GpioAddress led_address; // GPIO address for the associated LED
-  volatile uint32_t count; // Count of button presses
+  GpioAddress led_address;  // GPIO address for the associated LED
+  volatile uint32_t count;  // Count of button presses
 } ButtonStorage;
 
 // Initializes the button GPIOs and corresponding LED outputs

--- a/projects/fw_tutorial/inc/button.h
+++ b/projects/fw_tutorial/inc/button.h
@@ -18,8 +18,6 @@ typedef enum {
 typedef struct ButtonSettings {
   GpioAddress button_addresses[NUM_BUTTON_COLOURS];  // Array of GPIO addresses for each push button
   GpioAddress led_addresses[NUM_BUTTON_COLOURS];     // Array of GPIO addresses for each LED
-  GpioSettings gpio_settings;                        // GPIO settings for the push-button (input)
-  GpioSettings led_settings;                         // GPIO settings for LED (output)
   InterruptSettings interrupt_settings;              // Interrupt settings for push-buttons
   InterruptEdge interrupt_edge;                      // Interrupt trigger edge for push-buttons
 } ButtonSettings;

--- a/projects/fw_tutorial/inc/button.h
+++ b/projects/fw_tutorial/inc/button.h
@@ -2,7 +2,7 @@
 // Push button module for LED control written for the Tutorial board
 // This module is used as an introduction to Midnight Sun style firmware.
 // It is organized in such a way as to expose the user to basic fundamentals
-// and principals we follow when writing drivers and modules
+// and principles we follow when writing drivers and modules
 // Requires interrupts to be initialized
 #include "gpio.h"
 #include "gpio_it.h"

--- a/projects/fw_tutorial/inc/config.h
+++ b/projects/fw_tutorial/inc/config.h
@@ -1,0 +1,13 @@
+#pragma once
+// Configuration for defining and loading custom settings for the tutorial module
+#include "button.h"
+#include "potentiometer.h"
+
+// ADC periodic polling rate
+#define CONFIG_ADC_UPDATE_PERIOD_S 2
+
+// Loads the button configurations for the button module
+ButtonSettings *config_load_buttons(void);
+
+// Loads the potentiometer configurations for the potentiometer module
+PotentiometerSettings *config_load_potentiometer(void);

--- a/projects/fw_tutorial/inc/potentiometer.h
+++ b/projects/fw_tutorial/inc/potentiometer.h
@@ -7,15 +7,15 @@
 
 // Potentiometer settings structure
 typedef struct PotentiometerSettings {
-  GpioAddress adc_address; // Address of the ADC pin
-  GpioSettings adc_settings; // GPIO ADC settings
-  uint32_t update_period_s; // Update period of the ADC
+  GpioAddress adc_address;    // Address of the ADC pin
+  GpioSettings adc_settings;  // GPIO ADC settings
+  uint32_t update_period_s;   // Update period of the ADC
 } PotentiometerSettings;
 
 // Potentiometer storage structure
 typedef struct PotentiometerStorage {
-  AdcChannel adc_channel; // ADC Channel to read data
-  uint32_t update_period_s; // Update period of the ADC
+  AdcChannel adc_channel;    // ADC Channel to read data
+  uint32_t update_period_s;  // Update period of the ADC
 } PotentiometerStorage;
 
 // Initializes the ADC and soft timers for periodically reading analog data through an ADC

--- a/projects/fw_tutorial/inc/potentiometer.h
+++ b/projects/fw_tutorial/inc/potentiometer.h
@@ -7,9 +7,8 @@
 
 // Potentiometer settings structure
 typedef struct PotentiometerSettings {
-  GpioAddress adc_address;    // Address of the ADC pin
-  GpioSettings adc_settings;  // GPIO ADC settings
-  uint32_t update_period_s;   // Update period of the ADC
+  GpioAddress adc_address;   // Address of the ADC pin
+  uint32_t update_period_s;  // Update period of the ADC
 } PotentiometerSettings;
 
 // Potentiometer storage structure

--- a/projects/fw_tutorial/inc/potentiometer.h
+++ b/projects/fw_tutorial/inc/potentiometer.h
@@ -1,0 +1,22 @@
+#pragma once
+// Potentiometer module for LED brightness control written for the Tutorial board
+// This module is used as an introduction to Midnight Sun style firmware.
+// It is organized in such a way as to expose the user to reading analog data
+// Requires soft timers and ADC to be initialized in SINGLE_SHOT mode
+#include "adc.h"
+
+// Potentiometer settings structure
+typedef struct PotentiometerSettings {
+  GpioAddress adc_address; // Address of the ADC pin
+  GpioSettings adc_settings; // GPIO ADC settings
+  uint32_t update_period_s; // Update period of the ADC
+} PotentiometerSettings;
+
+// Potentiometer storage structure
+typedef struct PotentiometerStorage {
+  AdcChannel adc_channel; // ADC Channel to read data
+  uint32_t update_period_s; // Update period of the ADC
+} PotentiometerStorage;
+
+// Initializes the ADC and soft timers for periodically reading analog data through an ADC
+StatusCode potentiometer_init(const PotentiometerSettings *settings, PotentiometerStorage *storage);

--- a/projects/fw_tutorial/rules.mk
+++ b/projects/fw_tutorial/rules.mk
@@ -1,0 +1,11 @@
+# Defines $(T)_SRC, $(T)_INC, $(T)_DEPS, and $(T)_CFLAGS for the build makefile.
+# Tests can be excluded by defining $(T)_EXCLUDE_TESTS.
+# Pre-defined:
+# $(T)_SRC_ROOT: $(T)_DIR/src
+# $(T)_INC_DIRS: $(T)_DIR/inc{/$(PLATFORM)}
+# $(T)_SRC: $(T)_DIR/src{/$(PLATFORM)}/*.{c,s}
+
+# Specify the libraries you want to include
+$(T)_DEPS := ms-common
+
+$(T)_test_button_MOCKS := gpio_it_register_interrupt

--- a/projects/fw_tutorial/src/button.c
+++ b/projects/fw_tutorial/src/button.c
@@ -1,6 +1,6 @@
+#include "button.h"
 #include <stddef.h>
 #include <stdio.h>
-#include "button.h"
 
 static void prv_button_callback(const GpioAddress *address, void *context) {
   ButtonStorage *storage = (ButtonStorage *)context;
@@ -28,11 +28,9 @@ StatusCode button_init(const ButtonSettings *settings, ButtonStorage *storage) {
 
     // Initializae the button GPIO and register its interrupt
     status_ok_or_return(gpio_init_pin(&settings->button_addresses[i], &settings->gpio_settings));
-    status_ok_or_return(gpio_it_register_interrupt(&settings->button_addresses[i],
-                                                   &settings->interrupt_settings,
-                                                   settings->interrupt_edge,
-                                                   prv_button_callback,
-                                                   &storage[i]));
+    status_ok_or_return(
+        gpio_it_register_interrupt(&settings->button_addresses[i], &settings->interrupt_settings,
+                                   settings->interrupt_edge, prv_button_callback, &storage[i]));
   }
 
   // Everything has been initialized properly

--- a/projects/fw_tutorial/src/button.c
+++ b/projects/fw_tutorial/src/button.c
@@ -18,16 +18,28 @@ StatusCode button_init(const ButtonSettings *settings, ButtonStorage *storage) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
 
+  // GPIO settings for push-button
+  GpioSettings gpio_settings = { .direction = GPIO_DIR_IN,
+                                 .state = GPIO_STATE_LOW,
+                                 .resistor = GPIO_RES_NONE,
+                                 .alt_function = GPIO_ALTFN_NONE };
+
+  // GPIO settings for LED
+  GpioSettings led_settings = { .direction = GPIO_DIR_OUT,
+                                .state = GPIO_STATE_LOW,
+                                .resistor = GPIO_RES_NONE,
+                                .alt_function = GPIO_ALTFN_NONE };
+
   // Initialize all the buttons
   for (uint8_t i = 0; i < NUM_BUTTON_COLOURS; i++) {
     // Store the LED address
     storage[i].led_address = settings->led_addresses[i];
 
     // Initialize the LED GPIO
-    status_ok_or_return(gpio_init_pin(&settings->led_addresses[i], &settings->led_settings));
+    status_ok_or_return(gpio_init_pin(&settings->led_addresses[i], &led_settings));
 
     // Initializae the button GPIO and register its interrupt
-    status_ok_or_return(gpio_init_pin(&settings->button_addresses[i], &settings->gpio_settings));
+    status_ok_or_return(gpio_init_pin(&settings->button_addresses[i], &gpio_settings));
     status_ok_or_return(
         gpio_it_register_interrupt(&settings->button_addresses[i], &settings->interrupt_settings,
                                    settings->interrupt_edge, prv_button_callback, &storage[i]));

--- a/projects/fw_tutorial/src/button.c
+++ b/projects/fw_tutorial/src/button.c
@@ -2,48 +2,14 @@
 #include <stddef.h>
 #include <stdio.h>
 
-static void prv_button_callback(const GpioAddress *address, void *context) {
-  ButtonStorage *storage = (ButtonStorage *)context;
-
-  // Increment counter
-  storage->count++;
-
-  // Toggle the appropriate LED
-  gpio_toggle_state(&storage->led_address);
-}
-
 StatusCode button_init(const ButtonSettings *settings, ButtonStorage *storage) {
   // Argument checking
   if (settings == NULL || storage == NULL) {
     return status_code(STATUS_CODE_INVALID_ARGS);
   }
 
-  // GPIO settings for push-button
-  GpioSettings gpio_settings = { .direction = GPIO_DIR_IN,
-                                 .state = GPIO_STATE_LOW,
-                                 .resistor = GPIO_RES_NONE,
-                                 .alt_function = GPIO_ALTFN_NONE };
-
-  // GPIO settings for LED
-  GpioSettings led_settings = { .direction = GPIO_DIR_OUT,
-                                .state = GPIO_STATE_LOW,
-                                .resistor = GPIO_RES_NONE,
-                                .alt_function = GPIO_ALTFN_NONE };
-
-  // Initialize all the buttons
-  for (uint8_t i = 0; i < NUM_BUTTON_COLOURS; i++) {
-    // Store the LED address
-    storage[i].led_address = settings->led_addresses[i];
-
-    // Initialize the LED GPIO
-    status_ok_or_return(gpio_init_pin(&settings->led_addresses[i], &led_settings));
-
-    // Initializae the button GPIO and register its interrupt
-    status_ok_or_return(gpio_init_pin(&settings->button_addresses[i], &gpio_settings));
-    status_ok_or_return(
-        gpio_it_register_interrupt(&settings->button_addresses[i], &settings->interrupt_settings,
-                                   settings->interrupt_edge, prv_button_callback, &storage[i]));
-  }
+  // Initialize all push-buttons (including interrupts) and LEDs
+  // Enter your code below ...
 
   // Everything has been initialized properly
   return STATUS_CODE_OK;

--- a/projects/fw_tutorial/src/button.c
+++ b/projects/fw_tutorial/src/button.c
@@ -1,0 +1,40 @@
+#include <stddef.h>
+#include <stdio.h>
+#include "button.h"
+
+static void prv_button_callback(const GpioAddress *address, void *context) {
+  ButtonStorage *storage = (ButtonStorage *)context;
+
+  // Increment counter
+  storage->count++;
+
+  // Toggle the appropriate LED
+  gpio_toggle_state(&storage->led_address);
+}
+
+StatusCode button_init(const ButtonSettings *settings, ButtonStorage *storage) {
+  // Argument checking
+  if (settings == NULL || storage == NULL) {
+    return status_code(STATUS_CODE_INVALID_ARGS);
+  }
+
+  // Initialize all the buttons
+  for (uint8_t i = 0; i < NUM_BUTTON_COLOURS; i++) {
+    // Store the LED address
+    storage[i].led_address = settings->led_addresses[i];
+
+    // Initialize the LED GPIO
+    status_ok_or_return(gpio_init_pin(&settings->led_addresses[i], &settings->led_settings));
+
+    // Initializae the button GPIO and register its interrupt
+    status_ok_or_return(gpio_init_pin(&settings->button_addresses[i], &settings->gpio_settings));
+    status_ok_or_return(gpio_it_register_interrupt(&settings->button_addresses[i],
+                                                   &settings->interrupt_settings,
+                                                   settings->interrupt_edge,
+                                                   prv_button_callback,
+                                                   &storage[i]));
+  }
+
+  // Everything has been initialized properly
+  return STATUS_CODE_OK;
+}

--- a/projects/fw_tutorial/src/config.c
+++ b/projects/fw_tutorial/src/config.c
@@ -1,0 +1,49 @@
+#include "config.h"
+
+// Button settings
+static ButtonSettings button_settings = {
+  .button_addresses = {
+    [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 0 }, // Green button pin
+    [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_A, 7 } }, // Yellow button pin
+  .led_addresses = {
+    [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 3 }, // Green button LED pin
+    [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_B, 4 } }, // Yellow button LED pin
+  .gpio_settings = {
+    .direction = GPIO_DIR_IN,
+    .state = GPIO_STATE_LOW,
+    .resistor = GPIO_RES_NONE,
+    .alt_function = GPIO_ALTFN_NONE
+  },
+  .led_settings = {
+    .direction = GPIO_DIR_OUT,
+    .state = GPIO_STATE_LOW,
+    .resistor = GPIO_RES_NONE,
+    .alt_function = GPIO_ALTFN_NONE
+  },
+  .interrupt_settings = {
+    .type = INTERRUPT_TYPE_INTERRUPT,
+    .priority = INTERRUPT_PRIORITY_NORMAL // No other interrupts, leave as normal
+  },
+  .interrupt_edge = INTERRUPT_EDGE_RISING // Trigger on the rising edge
+};
+
+// Potentiometer settings
+static PotentiometerSettings potentiometer_settings = {
+  // TODO(ELEC-624): Change this once hardware revision updates
+  .adc_address = { GPIO_PORT_A, 0 }, // Potentiometer pin
+  .adc_settings = {
+    .direction = GPIO_DIR_IN,
+    .state = GPIO_STATE_LOW,
+    .resistor = GPIO_RES_NONE,
+    .alt_function = GPIO_ALTFN_ANALOG // Alternate function as ADC
+  },
+  .update_period_s = CONFIG_ADC_UPDATE_PERIOD_S // Update period
+};
+
+ButtonSettings *config_load_buttons(void) {
+  return &button_settings;
+}
+
+PotentiometerSettings *config_load_potentiometer(void) {
+  return &potentiometer_settings;
+}

--- a/projects/fw_tutorial/src/config.c
+++ b/projects/fw_tutorial/src/config.c
@@ -2,20 +2,14 @@
 
 // Button settings
 static ButtonSettings button_settings = {
-  .button_addresses = { [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 0 },     // Green button pin
-                        [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_A, 7 } },  // Yellow button pin
-  .led_addresses = { [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 3 },        // Green button LED pin
-                     [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_B, 4 } },     // Yellow button LED pin
-  // No other interrupts expected, leave priority as normal
-  .interrupt_settings = { INTERRUPT_TYPE_INTERRUPT, INTERRUPT_PRIORITY_NORMAL },
-  .interrupt_edge = INTERRUPT_EDGE_RISING  // Trigger on the rising edge
+  // Populate button settings with appropriate configurations
+  // Enter your code below ...
 };
 
 // Potentiometer settings
 static PotentiometerSettings potentiometer_settings = {
-  // TODO(ELEC-624): Change this once hardware revision updates
-  .adc_address = { GPIO_PORT_A, 0 },             // Potentiometer pin
-  .update_period_s = CONFIG_ADC_UPDATE_PERIOD_S  // Update period
+  // Populate LED settings with appropriate configurations
+  // Enter your code below ...
 };
 
 ButtonSettings *config_load_buttons(void) {

--- a/projects/fw_tutorial/src/config.c
+++ b/projects/fw_tutorial/src/config.c
@@ -2,42 +2,36 @@
 
 // Button settings
 static ButtonSettings button_settings = {
-  .button_addresses = {
-    [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 0 }, // Green button pin
-    [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_A, 7 } }, // Yellow button pin
-  .led_addresses = {
-    [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 3 }, // Green button LED pin
-    [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_B, 4 } }, // Yellow button LED pin
-  .gpio_settings = {
-    .direction = GPIO_DIR_IN,
-    .state = GPIO_STATE_LOW,
-    .resistor = GPIO_RES_NONE,
-    .alt_function = GPIO_ALTFN_NONE
-  },
-  .led_settings = {
-    .direction = GPIO_DIR_OUT,
-    .state = GPIO_STATE_LOW,
-    .resistor = GPIO_RES_NONE,
-    .alt_function = GPIO_ALTFN_NONE
-  },
+  .button_addresses = { [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 0 },     // Green button pin
+                        [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_A, 7 } },  // Yellow button pin
+  .led_addresses = { [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 3 },        // Green button LED pin
+                     [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_B, 4 } },     // Yellow button LED pin
+  .gpio_settings = { .direction = GPIO_DIR_IN,
+                     .state = GPIO_STATE_LOW,
+                     .resistor = GPIO_RES_NONE,
+                     .alt_function = GPIO_ALTFN_NONE },
+  .led_settings = { .direction = GPIO_DIR_OUT,
+                    .state = GPIO_STATE_LOW,
+                    .resistor = GPIO_RES_NONE,
+                    .alt_function = GPIO_ALTFN_NONE },
   .interrupt_settings = {
     .type = INTERRUPT_TYPE_INTERRUPT,
-    .priority = INTERRUPT_PRIORITY_NORMAL // No other interrupts, leave as normal
+    .priority = INTERRUPT_PRIORITY_NORMAL  // No other interrupts, leave as normal
   },
-  .interrupt_edge = INTERRUPT_EDGE_RISING // Trigger on the rising edge
+  .interrupt_edge = INTERRUPT_EDGE_RISING  // Trigger on the rising edge
 };
 
 // Potentiometer settings
 static PotentiometerSettings potentiometer_settings = {
   // TODO(ELEC-624): Change this once hardware revision updates
-  .adc_address = { GPIO_PORT_A, 0 }, // Potentiometer pin
+  .adc_address = { GPIO_PORT_A, 0 },  // Potentiometer pin
   .adc_settings = {
     .direction = GPIO_DIR_IN,
     .state = GPIO_STATE_LOW,
     .resistor = GPIO_RES_NONE,
-    .alt_function = GPIO_ALTFN_ANALOG // Alternate function as ADC
+    .alt_function = GPIO_ALTFN_ANALOG  // Alternate function as ADC
   },
-  .update_period_s = CONFIG_ADC_UPDATE_PERIOD_S // Update period
+  .update_period_s = CONFIG_ADC_UPDATE_PERIOD_S  // Update period
 };
 
 ButtonSettings *config_load_buttons(void) {

--- a/projects/fw_tutorial/src/config.c
+++ b/projects/fw_tutorial/src/config.c
@@ -14,10 +14,11 @@ static ButtonSettings button_settings = {
                     .state = GPIO_STATE_LOW,
                     .resistor = GPIO_RES_NONE,
                     .alt_function = GPIO_ALTFN_NONE },
-  .interrupt_settings = {
-    .type = INTERRUPT_TYPE_INTERRUPT,
-    .priority = INTERRUPT_PRIORITY_NORMAL  // No other interrupts, leave as normal
-  },
+  .interrupt_settings =
+      {
+          .type = INTERRUPT_TYPE_INTERRUPT,
+          .priority = INTERRUPT_PRIORITY_NORMAL  // No other interrupts, leave as normal
+      },
   .interrupt_edge = INTERRUPT_EDGE_RISING  // Trigger on the rising edge
 };
 
@@ -25,12 +26,13 @@ static ButtonSettings button_settings = {
 static PotentiometerSettings potentiometer_settings = {
   // TODO(ELEC-624): Change this once hardware revision updates
   .adc_address = { GPIO_PORT_A, 0 },  // Potentiometer pin
-  .adc_settings = {
-    .direction = GPIO_DIR_IN,
-    .state = GPIO_STATE_LOW,
-    .resistor = GPIO_RES_NONE,
-    .alt_function = GPIO_ALTFN_ANALOG  // Alternate function as ADC
-  },
+  .adc_settings =
+      {
+          .direction = GPIO_DIR_IN,
+          .state = GPIO_STATE_LOW,
+          .resistor = GPIO_RES_NONE,
+          .alt_function = GPIO_ALTFN_ANALOG  // Alternate function as ADC
+      },
   .update_period_s = CONFIG_ADC_UPDATE_PERIOD_S  // Update period
 };
 

--- a/projects/fw_tutorial/src/config.c
+++ b/projects/fw_tutorial/src/config.c
@@ -6,33 +6,15 @@ static ButtonSettings button_settings = {
                         [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_A, 7 } },  // Yellow button pin
   .led_addresses = { [BUTTON_COLOUR_GREEN] = { GPIO_PORT_B, 3 },        // Green button LED pin
                      [BUTTON_COLOUR_YELLOW] = { GPIO_PORT_B, 4 } },     // Yellow button LED pin
-  .gpio_settings = { .direction = GPIO_DIR_IN,
-                     .state = GPIO_STATE_LOW,
-                     .resistor = GPIO_RES_NONE,
-                     .alt_function = GPIO_ALTFN_NONE },
-  .led_settings = { .direction = GPIO_DIR_OUT,
-                    .state = GPIO_STATE_LOW,
-                    .resistor = GPIO_RES_NONE,
-                    .alt_function = GPIO_ALTFN_NONE },
-  .interrupt_settings =
-      {
-          .type = INTERRUPT_TYPE_INTERRUPT,
-          .priority = INTERRUPT_PRIORITY_NORMAL  // No other interrupts, leave as normal
-      },
+  // No other interrupts expected, leave priority as normal
+  .interrupt_settings = { INTERRUPT_TYPE_INTERRUPT, INTERRUPT_PRIORITY_NORMAL },
   .interrupt_edge = INTERRUPT_EDGE_RISING  // Trigger on the rising edge
 };
 
 // Potentiometer settings
 static PotentiometerSettings potentiometer_settings = {
   // TODO(ELEC-624): Change this once hardware revision updates
-  .adc_address = { GPIO_PORT_A, 0 },  // Potentiometer pin
-  .adc_settings =
-      {
-          .direction = GPIO_DIR_IN,
-          .state = GPIO_STATE_LOW,
-          .resistor = GPIO_RES_NONE,
-          .alt_function = GPIO_ALTFN_ANALOG  // Alternate function as ADC
-      },
+  .adc_address = { GPIO_PORT_A, 0 },             // Potentiometer pin
   .update_period_s = CONFIG_ADC_UPDATE_PERIOD_S  // Update period
 };
 

--- a/projects/fw_tutorial/src/main.c
+++ b/projects/fw_tutorial/src/main.c
@@ -1,0 +1,39 @@
+// Standard library includes
+#include <stdbool.h>
+
+// Midnight Sun common includes
+#include "interrupt.h"
+#include "log.h"
+#include "soft_timer.h"
+#include "wait.h"
+
+// Module specific includes
+#include "config.h"
+#include "button.h"
+#include "potentiometer.h"
+
+// Button and potentiometer storage which will persist throughout the duration of the program
+static ButtonStorage button_storage[NUM_BUTTON_COLOURS];
+static PotentiometerStorage potentiometer_storage;
+
+int main(void) {
+  // Initialize
+  gpio_init();
+  interrupt_init();
+  soft_timer_init();
+  gpio_it_init();
+  adc_init(ADC_MODE_SINGLE);
+
+  // Initialize the button module
+  // This will expose push-button control of the on-board LEDs
+  button_init(config_load_buttons(), button_storage);
+
+  // Initialize the potentiometer module
+  // This will enable reading of analog data through the ADCs
+  potentiometer_init(config_load_potentiometer(), &potentiometer_storage);
+
+  // Superloop!
+  while (true) {
+    // Do stuff here!
+  }
+}

--- a/projects/fw_tutorial/src/main.c
+++ b/projects/fw_tutorial/src/main.c
@@ -34,6 +34,6 @@ int main(void) {
 
   // Superloop!
   while (true) {
-    // Do stuff here!
+    // Do other stuff here!
   }
 }

--- a/projects/fw_tutorial/src/main.c
+++ b/projects/fw_tutorial/src/main.c
@@ -8,8 +8,8 @@
 #include "wait.h"
 
 // Module specific includes
-#include "config.h"
 #include "button.h"
+#include "config.h"
 #include "potentiometer.h"
 
 // Button and potentiometer storage which will persist throughout the duration of the program

--- a/projects/fw_tutorial/src/potentiometer.c
+++ b/projects/fw_tutorial/src/potentiometer.c
@@ -5,5 +5,6 @@
 
 StatusCode potentiometer_init(const PotentiometerSettings *settings,
                               PotentiometerStorage *storage) {
+  // TODO(ELEC-624): Implement this once potentiometer pin has been re-mapped on hardware
   return STATUS_CODE_UNIMPLEMENTED;
 }

--- a/projects/fw_tutorial/src/potentiometer.c
+++ b/projects/fw_tutorial/src/potentiometer.c
@@ -1,7 +1,7 @@
+#include "potentiometer.h"
 #include <stddef.h>
 #include "log.h"
 #include "soft_timer.h"
-#include "potentiometer.h"
 
 StatusCode potentiometer_init(const PotentiometerSettings *settings,
                               PotentiometerStorage *storage) {

--- a/projects/fw_tutorial/src/potentiometer.c
+++ b/projects/fw_tutorial/src/potentiometer.c
@@ -1,0 +1,9 @@
+#include <stddef.h>
+#include "log.h"
+#include "soft_timer.h"
+#include "potentiometer.h"
+
+StatusCode potentiometer_init(const PotentiometerSettings *settings,
+                              PotentiometerStorage *storage) {
+  return STATUS_CODE_UNIMPLEMENTED;
+}

--- a/projects/fw_tutorial/test/test_button.c
+++ b/projects/fw_tutorial/test/test_button.c
@@ -1,14 +1,13 @@
-#include "test_helpers.h"
 #include "button.h"
 #include "config.h"
+#include "test_helpers.h"
 
 static ButtonStorage button_storage[NUM_BUTTON_COLOURS];
 
-StatusCode TEST_MOCK(gpio_it_register_interrupt) (const GpioAddress *address,
-                                                  const InterruptSettings *settings,
-                                                  InterruptEdge edge,
-                                                  GpioItCallback callback,
-                                                  void *context) {
+StatusCode TEST_MOCK(gpio_it_register_interrupt)(const GpioAddress *address,
+                                                 const InterruptSettings *settings,
+                                                 InterruptEdge edge, GpioItCallback callback,
+                                                 void *context) {
   return STATUS_CODE_OK;
 }
 

--- a/projects/fw_tutorial/test/test_button.c
+++ b/projects/fw_tutorial/test/test_button.c
@@ -2,8 +2,10 @@
 #include "config.h"
 #include "test_helpers.h"
 
+// Button storage
 static ButtonStorage button_storage[NUM_BUTTON_COLOURS];
 
+// Mocked `gpio_it_register_interrupt` function
 StatusCode TEST_MOCK(gpio_it_register_interrupt)(const GpioAddress *address,
                                                  const InterruptSettings *settings,
                                                  InterruptEdge edge, GpioItCallback callback,
@@ -16,11 +18,11 @@ void setup_test(void) {}
 void teardown_test(void) {}
 
 void test_invalid_input(void) {
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, button_init(NULL, button_storage));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, button_init(config_load_buttons(), NULL));
-  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, button_init(NULL, NULL));
+  // Test for invalid inputs
+  // Enter your code below ...
 }
 
 void test_valid_input(void) {
-  TEST_ASSERT_OK(button_init(config_load_buttons(), button_storage));
+  // Test for valid inputs
+  // Enter your code below ...
 }

--- a/projects/fw_tutorial/test/test_button.c
+++ b/projects/fw_tutorial/test/test_button.c
@@ -1,0 +1,27 @@
+#include "test_helpers.h"
+#include "button.h"
+#include "config.h"
+
+static ButtonStorage button_storage[NUM_BUTTON_COLOURS];
+
+StatusCode TEST_MOCK(gpio_it_register_interrupt) (const GpioAddress *address,
+                                                  const InterruptSettings *settings,
+                                                  InterruptEdge edge,
+                                                  GpioItCallback callback,
+                                                  void *context) {
+  return STATUS_CODE_OK;
+}
+
+void setup_test(void) {}
+
+void teardown_test(void) {}
+
+void test_invalid_input(void) {
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, button_init(NULL, button_storage));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, button_init(config_load_buttons(), NULL));
+  TEST_ASSERT_EQUAL(STATUS_CODE_INVALID_ARGS, button_init(NULL, NULL));
+}
+
+void test_valid_input(void) {
+  TEST_ASSERT_OK(button_init(config_load_buttons(), button_storage));
+}


### PR DESCRIPTION
Module 1 of 2 for the Firmware On-boarding Tutorial (written for the HW Tutorial Board)

Includes:
- Push buttons to control LEDs (example code and exercises)
- ADC to log analog data from potentiometer (not implemented due to hardware issue)
- Unit test and mock function examples 