### PR TITLE
ELEC 634: Fix ADC not completing conversions

### DIFF
--- a/libraries/ms-common/src/stm32f0xx/adc.c
+++ b/libraries/ms-common/src/stm32f0xx/adc.c
@@ -22,7 +22,6 @@ typedef struct AdcInterrupt {
 typedef struct AdcStatus {
   uint32_t sequence;
   bool continuous;
-  volatile bool conv_complete;
 } AdcStatus;
 
 static AdcInterrupt s_adc_interrupts[NUM_ADC_CHANNELS];
@@ -190,9 +189,8 @@ StatusCode adc_read_raw(AdcChannel adc_channel, uint16_t *reading) {
   }
 
   if (!s_adc_status.continuous) {
-    s_adc_status.conv_complete = false;
     ADC_StartOfConversion(ADC1);
-    while (!s_adc_status.conv_complete) {
+    while (ADC_GetFlagStatus(ADC1, ADC_FLAG_EOSEQ)) {
     }
   }
 
@@ -254,7 +252,6 @@ void ADC1_COMP_IRQHandler() {
 
   if (ADC_GetITStatus(ADC1, ADC_IT_EOSEQ)) {
     s_adc_status.sequence = ADC1->CHSELR;
-    s_adc_status.conv_complete = true;
     ADC_ClearITPendingBit(ADC1, ADC_IT_EOSEQ);
   }
 }


### PR DESCRIPTION
ADC is not properly registering its completion of conversions since the introduction of the `conv_complete` boolean. 

- Bench tested on Power Distribution Rev 3
- @g-jessmuir tested on Hardware Tutorial Board