### PR TITLE
ELEC-636: Remove redundant linter case

### DIFF
--- a/lint.py
+++ b/lint.py
@@ -3627,24 +3627,6 @@ def CheckBraces(filename, clean_lines, linenum, error):
 
     line = clean_lines.elided[linenum]  # get rid of comments and strings
 
-    if Match(r'\s*{\s*$', line):
-        # We allow an open brace to start a line in the case where someone is using
-        # braces in a block to explicitly create a new scope, which is commonly used
-        # to control the lifetime of stack-allocated variables.  Braces are also
-        # used for brace initializers inside function calls.  We don't detect this
-        # perfectly: we just don't complain if the last non-whitespace character on
-        # the previous non-blank line is ',', ';', ':', '(', '{', or '}', or if the
-        # previous line starts a preprocessor block. We also allow a brace on the
-        # following line if it is part of an array initialization and would not fit
-        # within the 80 character limit of the preceding line.
-        prevline = GetPreviousNonBlankLine(clean_lines, linenum)[0]
-        if (not Search(r'[,;:}{(]\s*$', prevline) and
-                not Match(r'\s*#', prevline) and
-                not (GetLineWidth(prevline) > _line_length - 2 and
-                     '[]' in prevline)):
-            error(filename, linenum, 'whitespace/braces', 4,
-                  '{ should almost always be at the end of the previous line')
-
     # An else clause should be on the same line as the preceding closing brace.
     if Match(r'\s*else\b\s*(?:if\b|\{|$)', line):
         prevline = GetPreviousNonBlankLine(clean_lines, linenum)[0]


### PR DESCRIPTION
The whitespace/braces case is pretty much handled implicitly by our
clang-format rules. In certain cases, this clashes with the formatting
that clang-format provides, resulting in no way to pass CI.

As a fix, we remove this check from our cpplint.py fork, as we check
that clang-format has been applied on each PR anyways.