### PR TITLE
ELEC-580: Add Center Console BPS Fault Indicator

### DIFF
--- a/projects/driver_controls_center_console/inc/bps_indicator.h
+++ b/projects/driver_controls_center_console/inc/bps_indicator.h
@@ -1,0 +1,16 @@
+#pragma once
+// Module for indicating when the Strobe Light is turned on in the case of a
+// BPS fault that the BMS detects. The Center Console board needs to provide
+// the Driver with an illuminated dash indication of a BPS fault, to warn that
+// the Main Power Switch is opening.
+//
+// In order to consolidate the logic, we use the Strobe Light CAN control
+// message, which is controlled by Driver Controls: Pedal. Otherwise, we can
+// duplicate the logic and process the BMS Heartbeat Messages, like the Driver
+// Controls Master board does.
+//
+// Expects soft_timer, can, interrupts to be enabled.
+#include "status.h"
+
+// Configures the BPS Fault Dash Indicator handler.
+StatusCode bps_indicator_init(void);

--- a/projects/driver_controls_center_console/src/bps_indicator.c
+++ b/projects/driver_controls_center_console/src/bps_indicator.c
@@ -1,0 +1,46 @@
+#include "bps_indicator.h"
+
+#include <stdint.h>
+
+#include "can.h"
+#include "can_msg_defs.h"
+#include "can_unpack.h"
+#include "center_console_event.h"
+#include "event_queue.h"
+#include "exported_enums.h"
+#include "log.h"
+#include "status.h"
+
+// CanRxHandlerCb
+static StatusCode prv_strobe_rx(const CanMessage *msg, void *context, CanAckStatus *ack_reply) {
+  (void)context;
+  (void)ack_reply;
+
+  uint8_t light_id = 0;
+  uint8_t light_state = 0;
+  CAN_UNPACK_LIGHTS_STATE(msg, &light_id, &light_state);
+
+  // Ignore anything that isn't addressed to the Strobe Light, since we want
+  // to cause transitions in the BPS Fault Dash Indicator LED FSM.
+  if (light_id != EE_LIGHT_TYPE_STROBE) {
+    return STATUS_CODE_OK;
+  }
+
+  const EventId can_map_to_local[NUM_EE_LIGHT_STATES] = {
+    [EE_LIGHT_STATE_OFF] = CENTER_CONSOLE_EVENT_BUTTON_SET_STATE_OFF,
+    [EE_LIGHT_STATE_ON] = CENTER_CONSOLE_EVENT_BUTTON_SET_STATE_ON,
+  };
+
+  if (light_state >= NUM_EE_LIGHT_STATES) {
+    return status_code(STATUS_CODE_OUT_OF_RANGE);
+  }
+
+  return event_raise(can_map_to_local[light_state], EE_CENTER_CONSOLE_DIGITAL_INPUT_BPS);
+}
+
+StatusCode bps_indicator_init(void) {
+  status_ok_or_return(
+      can_register_rx_handler(SYSTEM_CAN_MESSAGE_LIGHTS_STATE, prv_strobe_rx, NULL));
+
+  return STATUS_CODE_OK;
+}

--- a/projects/driver_controls_center_console/src/main.c
+++ b/projects/driver_controls_center_console/src/main.c
@@ -4,6 +4,7 @@
 #include "config.h"
 
 #include "adc.h"
+#include "bps_indicator.h"
 #include "button_led.h"
 #include "button_led_radio.h"
 #include "center_console.h"
@@ -131,6 +132,8 @@ int main() {
         },
   };
   status_ok_or_return(center_console_init(&cc_storage));
+
+  status_ok_or_return(bps_indicator_init());
 
 #if defined(CENTER_CONSOLE_FLAG_ENABLE_5V_MONITOR)
   // Enable 5V monitor

--- a/projects/driver_controls_center_console/test/test_bps_indicator.c
+++ b/projects/driver_controls_center_console/test/test_bps_indicator.c
@@ -34,7 +34,7 @@ void setup_test(void) {
 
   CanSettings settings = {
     .device_id = SYSTEM_CAN_DEVICE_DRIVER_CONTROLS_CENTER_CONSOLE,
-    .bitrate = CAN_HW_BITRATE_250KBPS,
+    .bitrate = CAN_HW_BITRATE_500KBPS,
     .rx_event = CENTER_CONSOLE_EVENT_CAN_RX,
     .tx_event = CENTER_CONSOLE_EVENT_CAN_TX,
     .fault_event = CENTER_CONSOLE_EVENT_CAN_FAULT,

--- a/projects/driver_controls_center_console/test/test_bps_indicator.c
+++ b/projects/driver_controls_center_console/test/test_bps_indicator.c
@@ -1,0 +1,82 @@
+#include "bps_indicator.h"
+
+#include "center_console_event.h"
+#include "config.h"
+
+#include "can.h"
+#include "can_ack.h"
+#include "can_msg_defs.h"
+#include "can_transmit.h"
+
+#include "event_queue.h"
+#include "gpio.h"
+#include "gpio_it.h"
+#include "interrupt.h"
+#include "log.h"
+#include "soft_timer.h"
+
+#include "exported_enums.h"
+#include "ms_test_helpers.h"
+#include "test_helpers.h"
+#include "unity.h"
+
+static CanStorage s_storage = { 0 };
+
+void setup_test(void) {
+  event_queue_init();
+  interrupt_init();
+  soft_timer_init();
+
+  // GPIO initialization
+  gpio_init();
+  interrupt_init();
+  gpio_it_init();
+
+  CanSettings settings = {
+    .device_id = SYSTEM_CAN_DEVICE_DRIVER_CONTROLS_CENTER_CONSOLE,
+    .bitrate = CAN_HW_BITRATE_250KBPS,
+    .rx_event = CENTER_CONSOLE_EVENT_CAN_RX,
+    .tx_event = CENTER_CONSOLE_EVENT_CAN_TX,
+    .fault_event = CENTER_CONSOLE_EVENT_CAN_FAULT,
+    .tx = { GPIO_PORT_A, 12 },
+    .rx = { GPIO_PORT_A, 11 },
+    .loopback = true,
+  };
+  can_init(&s_storage, &settings);
+
+  TEST_ASSERT_OK(bps_indicator_init());
+}
+
+void teardown_test(void) {}
+
+void test_bps_indicator_raises_off_when_strobe_off(void) {
+  // Send a mock CAN Lights State Message
+  CanAckStatus expected_status = CAN_ACK_STATUS_OK;
+
+  CAN_TRANSMIT_LIGHTS_STATE(EE_LIGHT_TYPE_STROBE, EE_LIGHT_STATE_OFF);
+  MS_TEST_HELPER_CAN_TX_RX(CENTER_CONSOLE_EVENT_CAN_TX, CENTER_CONSOLE_EVENT_CAN_RX);
+
+  // No events should be raised
+  Event e = { 0 };
+  MS_TEST_HELPER_AWAIT_EVENT(e);
+  TEST_ASSERT_EQUAL(CENTER_CONSOLE_EVENT_BUTTON_SET_STATE_OFF, e.id);
+  TEST_ASSERT_EQUAL(EE_CENTER_CONSOLE_DIGITAL_INPUT_BPS, e.data);
+
+  TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, event_process(&e));
+}
+
+void test_bps_indicator_raises_on_when_strobe_on(void) {
+  // Send a mock CAN Lights State Message
+  CanAckStatus expected_status = CAN_ACK_STATUS_OK;
+
+  CAN_TRANSMIT_LIGHTS_STATE(EE_LIGHT_TYPE_STROBE, EE_LIGHT_STATE_ON);
+  MS_TEST_HELPER_CAN_TX_RX(CENTER_CONSOLE_EVENT_CAN_TX, CENTER_CONSOLE_EVENT_CAN_RX);
+
+  // No events should be raised
+  Event e = { 0 };
+  MS_TEST_HELPER_AWAIT_EVENT(e);
+  TEST_ASSERT_EQUAL(CENTER_CONSOLE_EVENT_BUTTON_SET_STATE_ON, e.id);
+  TEST_ASSERT_EQUAL(EE_CENTER_CONSOLE_DIGITAL_INPUT_BPS, e.data);
+
+  TEST_ASSERT_EQUAL(STATUS_CODE_EMPTY, event_process(&e));
+}


### PR DESCRIPTION
Add code to drive the BPS Fault Dash Indicator LED by piggybacking the
CAN message used to notify Lights to activate the Strobe. This is
because there's currently some inherent coupling between the Lights
board, which is told when to turn on the Strobe, and the required BPS
Fault Dash Indicator is to reflect that state.

If we wish to process the message slightly faster instead of waiting for
the Driver Controls master board to notify everyone, we could also
listen to the BMS Heartbeat.